### PR TITLE
Wallet functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ lazy_static = "1.5.0"
 rand_core = "0.6.4"
 typenum = "1.17" 
 
+
 [lib]
 name = "chain_gang"
 crate-type = ["cdylib", "lib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ sha2 = "0.10.8"
 k256 = { version = "0.13.3", features = ["alloc", "arithmetic", "digest", "ecdsa", "once_cell", "pkcs8", "precomputed-tables", "schnorr",
     "sha2", "sha256", "signature", "std"]}
 snowflake = "1.3"
-
 hmac = "0.12.1"
 base58 = "0.2.0"
+pbkdf2 = "0.12.2"
 
 # Used by the interface feature
 serde = { version = "1.0.86", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ pyo3 = { version = "0.21.2", optional = true }
 regex = "1.10.5"
 lazy_static = "1.5.0"
 rand_core = "0.6.4"
-
+typenum = "1.17" 
 
 [lib]
 name = "chain_gang"

--- a/README.md
+++ b/README.md
@@ -199,8 +199,18 @@ Wallet class has the following methods:
 * `get_address(self) -> String` - Return the address based on the public key
 * `to_wif(self) -> String` - Return the private key in WIF format
 * `get_network(self) -> String` - Returns the current network associated with this keypair
+* `to_int(self) -> Integer` - Returns the scaler value of the private key as a python integer
+* `to_hex(self) -> String` - Returns the scaler value of the private key as a string in hex format
 
 * `Wallet.generate_keypair(network) -> Wallet` - Given network (BSV_Testnet) return a keypair in Wallet format
+* `Wallet.wallet_from_hexstr(network, hexstr) -> Wallet` - Given a network identifier and scalar value as a hex string, return a keypair in Wallet format
+* `Wallet.wallet_from_bytes(network, bytes) -> Wallet` - Given a network identifier and a scalar value as a byte array, return a keypair in Wallet format
+
+The library provides some additional helper functions to handle keys in different formats. 
+* `wif_to_bytes(wif: string) -> bytes` - Given a key in WIF format, it returns a byte array of the scalar value of the private key
+* `bytes_to_wif(key_bytes, network) -> String` - Given a byte array and a network identifier, returns the WIF format for the private key
+* `wif_from_pw_nonce(password, nonce, optional<network>) -> WIF` - Given a password, nonce (strings) return a WIF format for the private key. The default for the network is BSV_Mainnet. For a testnet format, please use BSv_Testnet
+* `wallet_from_int(integer, network) -> Wallet` - Given a python integer and network identifier, return a keypair in Wallet format
 
 ![Bitcoin Keys](docs/diagrams/keys.png)
 

--- a/README.md
+++ b/README.md
@@ -203,14 +203,15 @@ Wallet class has the following methods:
 * `to_hex(self) -> String` - Returns the scaler value of the private key as a string in hex format
 
 * `Wallet.generate_keypair(network) -> Wallet` - Given network (BSV_Testnet) return a keypair in Wallet format
-* `Wallet.wallet_from_hexstr(network, hexstr) -> Wallet` - Given a network identifier and scalar value as a hex string, return a keypair in Wallet format
-* `Wallet.wallet_from_bytes(network, bytes) -> Wallet` - Given a network identifier and a scalar value as a byte array, return a keypair in Wallet format
+* `Wallet.from_hexstr(network, hexstr) -> Wallet` - Given a network identifier and scalar value as a hex string, return a keypair in Wallet format
+* `Wallet.from_bytes(network, bytes) -> Wallet` - Given a network identifier and a scalar value as a byte array, return a keypair in Wallet format
+* `Wallet.from_int(network, integer) -> Wallet` - Given a network identifier and a scaler value as an integer, return a keypair in Wallet format
 
 The library provides some additional helper functions to handle keys in different formats. 
 * `wif_to_bytes(wif: string) -> bytes` - Given a key in WIF format, it returns a byte array of the scalar value of the private key
 * `bytes_to_wif(key_bytes, network) -> String` - Given a byte array and a network identifier, returns the WIF format for the private key
 * `wif_from_pw_nonce(password, nonce, optional<network>) -> WIF` - Given a password, nonce (strings) return a WIF format for the private key. The default for the network is BSV_Mainnet. For a testnet format, please use BSv_Testnet
-* `wallet_from_int(integer, network) -> Wallet` - Given a python integer and network identifier, return a keypair in Wallet format
+
 
 ![Bitcoin Keys](docs/diagrams/keys.png)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-dependencies = ["requests==2.32.3", "python-bitcoinrpc==1.0"]
+dependencies = ["requests==2.32.3", "python-bitcoinrpc==1.0", "cryptography==43.0.1"]
 
 [tool.maturin]
 features = ["pyo3/extension-module", "python"]

--- a/python/src/requirements.txt
+++ b/python/src/requirements.txt
@@ -1,2 +1,3 @@
 requests
 python-bitcoinrpc
+cryptography

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -6,7 +6,7 @@ import sys
 sys.path.append("..")
 
 
-from tx_engine import Wallet, hash160, Tx, TxIn, TxOut, Script, create_wallet_from_pem_bytes
+from tx_engine import Wallet, hash160, Tx, TxIn, TxOut, Script, create_wallet_from_pem_bytes, wallet_from_int
 
 
 class WalletTest(unittest.TestCase):
@@ -118,19 +118,19 @@ class WalletTest(unittest.TestCase):
         self.assertEqual(wmain.get_network(), "BSV_Mainnet")
 
     def test_create_wallet_from_int(self):
-        w = Wallet(110943977574299588079135027069764758606913326570652510108968462252246438125737, network="BSV_Testnet")
+        w = wallet_from_int(110943977574299588079135027069764758606913326570652510108968462252246438125737, "BSV_Testnet")
         self.assertEqual(w.get_address(), "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s")
 
     def test_create_wallet_from_int_mainnet(self):
-        w = Wallet(110943977574299588079135027069764758606913326570652510108968462252246438125737, network="BSV_Mainnet")
+        w = wallet_from_int(110943977574299588079135027069764758606913326570652510108968462252246438125737, "BSV_Mainnet")
         self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
     def test_create_wallet_from_hex(self):
-        w = Wallet("f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9", network="BSV_Testnet")
+        w = Wallet.wallet_from_hexstr("BSV_Testnet", "f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
         self.assertEqual(w.get_address(), "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s")
 
     def test_create_wallet_from_hex_mainnet(self):
-        w = Wallet("f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9", network="BSV_Mainnet")
+        w = Wallet.wallet_from_hexstr("BSV_Mainnet","f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
         self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
     def test_wallet_to_int(self):
@@ -154,14 +154,14 @@ class WalletTest(unittest.TestCase):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
         pem_as_bytes = pem.encode()
 
-        w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
+        w = create_wallet_from_pem_bytes(pem_as_bytes, network="BSV_Testnet")
         expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
         self.assertEqual(w.get_address(), expected_output)
 
     def test_create_mainnet_key_from_pem(self):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
  
-        w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+        w = create_wallet_from_pem_bytes(pem.encode(), network="BSV_Mainnet")
         expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
         self.assertEqual(w.get_address(), expected_output)
 

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -90,32 +90,13 @@ class WalletTest(unittest.TestCase):
         w2 = Wallet.generate_keypair("BSV_Testnet")
         self.assertNotEqual(w1.get_address(), w2.get_address())
 
-    def test_get_network(self):
-        wif = "cSW9fDMxxHXDgeMyhbbHDsL5NNJkovSa2LTqHQWAERPdTZaVCab3"
-        wallet = Wallet(wif)
-        self.assertEqual(wallet.get_network(), "BSV_Testnet")
-
     def test_create_testnet_key_from_pem(self):
-        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
+        pem = '-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
         pem_as_bytes = pem.encode()
 
         w = create_wallet_from_pem_bytes(pem_as_bytes, network="BSV_Testnet")
         expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
         self.assertEqual(w.get_address(), expected_output)
-
-    def test_create_mainnet_key_from_pem(self):
-        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
-        pem_bytes = pem.encode()
-        w = create_wallet_from_pem_bytes(pem_bytes, network="BSV_Mainnet")
-        expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
-        self.assertEqual(w.get_address(), expected_output)
-
-    def test_get_network(self):
-        wtest = Wallet("cVoVmd5zY69LEevwGa5iq1Ba3oBc6J8xxUqdKuJCtuFWUJJngPPP")
-        wmain = Wallet("L5SWJi6972T55DTftAGbTggWRZtCRr3GtShADUqhPnbWDZAciATX")
-    
-        self.assertEqual(wtest.get_network(), "BSV_Testnet")
-        self.assertEqual(wmain.get_network(), "BSV_Mainnet")
 
     def test_create_wallet_from_int(self):
         w = Wallet.from_int("BSV_Testnet", 110943977574299588079135027069764758606913326570652510108968462252246438125737)
@@ -130,7 +111,7 @@ class WalletTest(unittest.TestCase):
         self.assertEqual(w.get_address(), "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s")
 
     def test_create_wallet_from_hex_mainnet(self):
-        w = Wallet.from_hexstr("BSV_Mainnet","f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
+        w = Wallet.from_hexstr("BSV_Mainnet", "f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
         self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
     def test_wallet_to_int(self):
@@ -145,22 +126,8 @@ class WalletTest(unittest.TestCase):
         w = Wallet("L5SWJi6972T55DTftAGbTggWRZtCRr3GtShADUqhPnbWDZAciATX")
         self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
-    def test_get_network(self):
-        wif = "cSW9fDMxxHXDgeMyhbbHDsL5NNJkovSa2LTqHQWAERPdTZaVCab3"
-        wallet = Wallet(wif)
-        self.assertEqual(wallet.get_network(), "BSV_Testnet")
-
-    def test_create_testnet_key_from_pem(self):
-        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
-        pem_as_bytes = pem.encode()
-
-        w = create_wallet_from_pem_bytes(pem_as_bytes, network="BSV_Testnet")
-        expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
-        self.assertEqual(w.get_address(), expected_output)
-
     def test_create_mainnet_key_from_pem(self):
-        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
- 
+        pem = '-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
         w = create_wallet_from_pem_bytes(pem.encode(), network="BSV_Mainnet")
         expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
         self.assertEqual(w.get_address(), expected_output)
@@ -168,9 +135,9 @@ class WalletTest(unittest.TestCase):
     def test_get_network(self):
         wtest = Wallet("cVvay9F4wkxrC6cLwThUnRHEajQ8FNoDEg1pbsgYjh7xYtkQ9LVZ")
         wmain = Wallet("L5ZbWEFDWhGb2f95Z3tMR6nAxW6iavhXAdsMVTE3EaTxJ9deQtub")
-    
         self.assertEqual(wtest.get_network(), "BSV_Testnet")
         self.assertEqual(wmain.get_network(), "BSV_Mainnet")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -150,6 +150,24 @@ class WalletTest(unittest.TestCase):
         wallet = Wallet(wif)
         self.assertEqual(wallet.get_network(), "BSV_Testnet")
 
+    def test_create_testnet_key_from_pem(self):
+        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
+        pem_as_bytes = pem.encode()
+        pass
+
+        # w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
+
+        # expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
+        # self.assertEqual(w.get_address(), expected_output)
+
+    def test_create_mainnet_key_from_pem(self):
+        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
+        pass
+ 
+        # w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+
+        # expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
+        # self.assertEqual(w.get_address(), expected_output)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -145,5 +145,11 @@ class WalletTest(unittest.TestCase):
         w = Wallet("L5SWJi6972T55DTftAGbTggWRZtCRr3GtShADUqhPnbWDZAciATX")
         self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
+    def test_get_network(self):
+        wif = "cSW9fDMxxHXDgeMyhbbHDsL5NNJkovSa2LTqHQWAERPdTZaVCab3"
+        wallet = Wallet(wif)
+        self.assertEqual(wallet.get_network(), "BSV_Testnet")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -111,11 +111,39 @@ class WalletTest(unittest.TestCase):
         self.assertEqual(w.get_address(), expected_output)
 
     def test_get_network(self):
-        wtest = Wallet("cVvay9F4wkxrC6cLwThUnRHEajQ8FNoDEg1pbsgYjh7xYtkQ9LVZ")
-        wmain = Wallet("L5ZbWEFDWhGb2f95Z3tMR6nAxW6iavhXAdsMVTE3EaTxJ9deQtub")
+        wtest = Wallet("cVoVmd5zY69LEevwGa5iq1Ba3oBc6J8xxUqdKuJCtuFWUJJngPPP")
+        wmain = Wallet("L5SWJi6972T55DTftAGbTggWRZtCRr3GtShADUqhPnbWDZAciATX")
     
         self.assertEqual(wtest.get_network(), "BSV_Testnet")
         self.assertEqual(wmain.get_network(), "BSV_Mainnet")
+
+    def test_create_wallet_from_int(self):
+        w = Wallet(110943977574299588079135027069764758606913326570652510108968462252246438125737, network="BSV_Testnet")
+        self.assertEqual(w.get_address(), "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s")
+
+    def test_create_wallet_from_int_mainnet(self):
+        w = Wallet(110943977574299588079135027069764758606913326570652510108968462252246438125737, network="BSV_Mainnet")
+        self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
+
+    def test_create_wallet_from_hex(self):
+        w = Wallet("f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9", network="BSV_Testnet")
+        self.assertEqual(w.get_address(), "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s")
+
+    def test_create_wallet_from_hex_mainnet(self):
+        w = Wallet("f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9", network="BSV_Mainnet")
+        self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
+
+    def test_wallet_to_int(self):
+        w = Wallet("cVoVmd5zY69LEevwGa5iq1Ba3oBc6J8xxUqdKuJCtuFWUJJngPPP")
+        self.assertEqual(w.to_int(), 110943977574299588079135027069764758606913326570652510108968462252246438125737)
+
+    def test_wallet_to_hex(self):
+        w = Wallet("cVoVmd5zY69LEevwGa5iq1Ba3oBc6J8xxUqdKuJCtuFWUJJngPPP")
+        self.assertEqual(w.to_hex(), "f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
+
+    def test_create_wallet_mainnet(self):
+        w = Wallet("L5SWJi6972T55DTftAGbTggWRZtCRr3GtShADUqhPnbWDZAciATX")
+        self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -6,7 +6,7 @@ import sys
 sys.path.append("..")
 
 
-from tx_engine import Wallet, hash160, Tx, TxIn, TxOut, Script, create_wallet_from_pem_bytes, wallet_from_int
+from tx_engine import Wallet, hash160, Tx, TxIn, TxOut, Script, create_wallet_from_pem_bytes
 
 
 class WalletTest(unittest.TestCase):
@@ -118,19 +118,19 @@ class WalletTest(unittest.TestCase):
         self.assertEqual(wmain.get_network(), "BSV_Mainnet")
 
     def test_create_wallet_from_int(self):
-        w = wallet_from_int(110943977574299588079135027069764758606913326570652510108968462252246438125737, "BSV_Testnet")
+        w = Wallet.from_int("BSV_Testnet", 110943977574299588079135027069764758606913326570652510108968462252246438125737)
         self.assertEqual(w.get_address(), "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s")
 
     def test_create_wallet_from_int_mainnet(self):
-        w = wallet_from_int(110943977574299588079135027069764758606913326570652510108968462252246438125737, "BSV_Mainnet")
+        w = Wallet.from_int("BSV_Mainnet", 110943977574299588079135027069764758606913326570652510108968462252246438125737)
         self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
     def test_create_wallet_from_hex(self):
-        w = Wallet.wallet_from_hexstr("BSV_Testnet", "f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
+        w = Wallet.from_hexstr("BSV_Testnet", "f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
         self.assertEqual(w.get_address(), "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s")
 
     def test_create_wallet_from_hex_mainnet(self):
-        w = Wallet.wallet_from_hexstr("BSV_Mainnet","f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
+        w = Wallet.from_hexstr("BSV_Mainnet","f54810e800d14e8b2f978ddb839ce9594ddc1459ee300d0c3b9990a70d3220a9")
         self.assertEqual(w.get_address(), "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3")
 
     def test_wallet_to_int(self):

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -98,21 +98,24 @@ class WalletTest(unittest.TestCase):
     def test_create_testnet_key_from_pem(self):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
         pem_as_bytes = pem.encode()
-        pass
 
-        # w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
-
-        # expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
-        # self.assertEqual(w.get_address(), expected_output)
+        w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
+        expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
+        self.assertEqual(w.get_address(), expected_output)
 
     def test_create_mainnet_key_from_pem(self):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
-        pass
  
-        # w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+        w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+        expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
+        self.assertEqual(w.get_address(), expected_output)
 
-        # expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
-        # self.assertEqual(w.get_address(), expected_output)
+    def test_get_network(self):
+        wtest = Wallet("cVvay9F4wkxrC6cLwThUnRHEajQ8FNoDEg1pbsgYjh7xYtkQ9LVZ")
+        wmain = Wallet("L5ZbWEFDWhGb2f95Z3tMR6nAxW6iavhXAdsMVTE3EaTxJ9deQtub")
+    
+        self.assertEqual(wtest.get_network(), "BSV_Testnet")
+        self.assertEqual(wmain.get_network(), "BSV_Mainnet")
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -153,21 +153,24 @@ class WalletTest(unittest.TestCase):
     def test_create_testnet_key_from_pem(self):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
         pem_as_bytes = pem.encode()
-        pass
 
-        # w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
-
-        # expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
-        # self.assertEqual(w.get_address(), expected_output)
+        w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
+        expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
+        self.assertEqual(w.get_address(), expected_output)
 
     def test_create_mainnet_key_from_pem(self):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
-        pass
  
-        # w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+        w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+        expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
+        self.assertEqual(w.get_address(), expected_output)
 
-        # expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
-        # self.assertEqual(w.get_address(), expected_output)
+    def test_get_network(self):
+        wtest = Wallet("cVvay9F4wkxrC6cLwThUnRHEajQ8FNoDEg1pbsgYjh7xYtkQ9LVZ")
+        wmain = Wallet("L5ZbWEFDWhGb2f95Z3tMR6nAxW6iavhXAdsMVTE3EaTxJ9deQtub")
+    
+        self.assertEqual(wtest.get_network(), "BSV_Testnet")
+        self.assertEqual(wmain.get_network(), "BSV_Mainnet")
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -95,6 +95,24 @@ class WalletTest(unittest.TestCase):
         wallet = Wallet(wif)
         self.assertEqual(wallet.get_network(), "BSV_Testnet")
 
+    def test_create_testnet_key_from_pem(self):
+        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
+        pem_as_bytes = pem.encode()
+        pass
+
+        # w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
+
+        # expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
+        # self.assertEqual(w.get_address(), expected_output)
+
+    def test_create_mainnet_key_from_pem(self):
+        pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
+        pass
+ 
+        # w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+
+        # expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
+        # self.assertEqual(w.get_address(), expected_output)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_wallet.py
+++ b/python/src/tests/test_wallet.py
@@ -6,7 +6,7 @@ import sys
 sys.path.append("..")
 
 
-from tx_engine import Wallet, hash160, Tx, TxIn, TxOut, Script
+from tx_engine import Wallet, hash160, Tx, TxIn, TxOut, Script, create_wallet_from_pem_bytes
 
 
 class WalletTest(unittest.TestCase):
@@ -99,14 +99,14 @@ class WalletTest(unittest.TestCase):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
         pem_as_bytes = pem.encode()
 
-        w = Wallet.create_key_from_pem(pem_as_bytes, network="BSV_Testnet")
+        w = create_wallet_from_pem_bytes(pem_as_bytes, network="BSV_Testnet")
         expected_output = "mg7k4cWKZAH6dHFAk4GPjuWFvmFZBHKf7s"
         self.assertEqual(w.get_address(), expected_output)
 
     def test_create_mainnet_key_from_pem(self):
         pem ='-----BEGIN PRIVATE KEY-----\nMIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg9UgQ6ADRTosvl43bg5zp\nWU3cFFnuMA0MO5mQpw0yIKmhRANCAAS0+wZKso7C2qmxYsbEvK88us9aop4JTDb9\nnjAqlYPw6ik7Iybiu1aYtVggdWSDfJrEVQcuNdcWGuKohHfU/F6X\n-----END PRIVATE KEY-----\n'
- 
-        w = Wallet.create_key_from_pem(pem, network="BSV_Mainnet")
+        pem_bytes = pem.encode()
+        w = create_wallet_from_pem_bytes(pem_bytes, network="BSV_Mainnet")
         expected_output = "1bnmZRLk8qqrAmZ2VJ1uzHw4merFyKSP3"
         self.assertEqual(w.get_address(), expected_output)
 

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -4,7 +4,7 @@ This is a tx_engine doc str
 # noqa: F401 - 'x' - imported but unused
 
 from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Wallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -11,3 +11,4 @@ from tx_engine.tx.sighash import SIGHASH  # noqa: F401
 from tx_engine.interface.interface_factory import interface_factory   # noqa: F401
 from tx_engine.interface.woc_interface import WoCInterface   # noqa: F401
 from tx_engine.interface.mock_interface import MockInterface   # noqa: F401
+from tx_engine.misc.cryptography_utils import create_wallet_from_pem_bytes # noqa: F401

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -4,7 +4,7 @@ This is a tx_engine doc str
 # noqa: F401 - 'x' - imported but unused
 
 from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Wallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -4,11 +4,11 @@ This is a tx_engine doc str
 # noqa: F401 - 'x' - imported but unused
 
 from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Wallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, wallet_from_int  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401
 from tx_engine.interface.interface_factory import interface_factory   # noqa: F401
 from tx_engine.interface.woc_interface import WoCInterface   # noqa: F401
 from tx_engine.interface.mock_interface import MockInterface   # noqa: F401
-from tx_engine.misc.cryptography_utils import create_wallet_from_pem_bytes # noqa: F401
+from tx_engine.engine.cryptography_utils import create_wallet_from_pem_bytes # noqa: F401

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -4,11 +4,11 @@ This is a tx_engine doc str
 # noqa: F401 - 'x' - imported but unused
 
 from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Wallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401
 from tx_engine.interface.interface_factory import interface_factory   # noqa: F401
 from tx_engine.interface.woc_interface import WoCInterface   # noqa: F401
 from tx_engine.interface.mock_interface import MockInterface   # noqa: F401
-from tx_engine.engine.cryptography_utils import create_wallet_from_pem_bytes # noqa: F401
+from tx_engine.engine.cryptography_utils import create_wallet_from_pem_bytes  # noqa: F401

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -4,7 +4,7 @@ This is a tx_engine doc str
 # noqa: F401 - 'x' - imported but unused
 
 from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Wallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, wallet_from_int  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401

--- a/python/src/tx_engine/engine/cryptography_utils.py
+++ b/python/src/tx_engine/engine/cryptography_utils.py
@@ -3,15 +3,17 @@ from tx_engine import Wallet
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.backends import default_backend
 
+
 def create_wallet_from_pem_file(pem_file_path: str, network: str) -> Wallet:
-     # Load the PEM file
+    # Load the PEM file
     with open(pem_file_path, 'rb') as pem_file:
         pem_data = pem_file.read()
 
     return create_wallet_from_pem_bytes(pem_data, network)
 
+
 def create_wallet_from_pem_bytes(pem_data: bytes, network: str) -> Wallet:
-     # Load the private key from the PEM data
+    # Load the private key from the PEM data
     private_key = load_pem_private_key(pem_data, password=None, backend=default_backend())
 
     # Extract the private numbers (this includes the scalar/private key value)

--- a/python/src/tx_engine/engine/cryptography_utils.py
+++ b/python/src/tx_engine/engine/cryptography_utils.py
@@ -23,4 +23,4 @@ def create_wallet_from_pem_bytes(pem_data: bytes, network: str) -> Wallet:
     # Convert the scalar value to bytes
     private_key_bytes = private_key_scalar.to_bytes((private_key_scalar.bit_length() + 7) // 8, byteorder='big')
 
-    return Wallet.wallet_from_bytes(network, private_key_bytes)
+    return Wallet.from_bytes(network, private_key_bytes)

--- a/python/src/tx_engine/misc/cryptography_utils.py
+++ b/python/src/tx_engine/misc/cryptography_utils.py
@@ -1,0 +1,26 @@
+from tx_engine import Wallet
+
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.backends import default_backend
+
+def create_wallet_from_pem_file(pem_file_path: str, network: str) -> Wallet:
+     # Load the PEM file
+    with open(pem_file_path, 'rb') as pem_file:
+        pem_data = pem_file.read()
+
+    return create_wallet_from_pem_bytes(pem_data, network)
+
+def create_wallet_from_pem_bytes(pem_data: bytes, network: str) -> Wallet:
+     # Load the private key from the PEM data
+    private_key = load_pem_private_key(pem_data, password=None, backend=default_backend())
+
+    # Extract the private numbers (this includes the scalar/private key value)
+    private_numbers = private_key.private_numbers()
+
+    # The scalar value of the private key (as an integer)
+    private_key_scalar = private_numbers.private_value
+
+    # Convert the scalar value to bytes
+    private_key_bytes = private_key_scalar.to_bytes((private_key_scalar.bit_length() + 7) // 8, byteorder='big')
+
+    return Wallet.create_wallet_from_bytes(network, private_key_bytes)

--- a/python/src/tx_engine/misc/cryptography_utils.py
+++ b/python/src/tx_engine/misc/cryptography_utils.py
@@ -23,4 +23,4 @@ def create_wallet_from_pem_bytes(pem_data: bytes, network: str) -> Wallet:
     # Convert the scalar value to bytes
     private_key_bytes = private_key_scalar.to_bytes((private_key_scalar.bit_length() + 7) // 8, byteorder='big')
 
-    return Wallet.create_wallet_from_bytes(network, private_key_bytes)
+    return Wallet.wallet_from_bytes(network, private_key_bytes)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,7 +1,5 @@
-use pyo3::{prelude::*, types::PyBytes};
-use pyo3::types::PyLong;
 use pyo3::Bound;
-use num_bigint::BigInt;
+use pyo3::{prelude::*, types::PyBytes};
 
 mod base58_checksum;
 mod hashes;
@@ -17,7 +15,10 @@ use crate::{
         hashes::{hash160, sha256d},
         py_script::PyScript,
         py_tx::{PyTx, PyTxIn, PyTxOut},
-        py_wallet::{address_to_public_key_hash, p2pkh_pyscript, public_key_to_address, wif_to_bytes, bytes_to_wif, generate_wif, PyWallet, wallet_from_int, MAIN_PRIVATE_KEY, TEST_PRIVATE_KEY},
+        py_wallet::{
+            address_to_public_key_hash, bytes_to_wif, generate_wif, p2pkh_pyscript,
+            public_key_to_address, wif_to_bytes, PyWallet, MAIN_PRIVATE_KEY, TEST_PRIVATE_KEY,
+        },
     },
     script::{stack::Stack, Script, TransactionlessChecker, ZChecker, NO_FLAGS},
     transaction::sighash::{sig_hash_preimage, sighash, SigHashCache},
@@ -168,39 +169,22 @@ pub fn py_bytes_to_wif(key_bytes: &[u8], network: &str) -> PyResult<String> {
 }
 
 #[pyfunction(name = "wif_from_pw_nonce")]
-pub fn py_generate_wif_from_pw_nonce(_py: Python, password: &str, nonce: &str, network: Option<&str>) -> String {
+pub fn py_generate_wif_from_pw_nonce(
+    _py: Python,
+    password: &str,
+    nonce: &str,
+    network: Option<&str>,
+) -> String {
     // Provide default value if `network` is None
-    let network = network.unwrap_or("testnet");
+    let network = network.unwrap_or("BSV_Testnet");
 
     // Example logic: derive WIF based on password, nonce, and network
     let wif = match network {
-        "mainnet" => generate_wif(password, nonce, "mainnet"),
-        _ => generate_wif(password, nonce, "testnet"), // Default to "testnet"
+        "BSV_Mainnet" => generate_wif(password, nonce, "BSV_Mainnet"),
+        _ => generate_wif(password, nonce, "BSV_Testnet"), // Default to "testnet"
     };
 
     wif
-}
-
-
-#[pyfunction(name = "wallet_from_int")]
-fn py_wallet_from_int(int_rep: &Bound<'_, PyAny>, network: &str) -> PyResult<PyWallet> {
-    // Use with_gil to get a reference to the Python interpreter
-    Python::with_gil(|_py| {
-        // Use the bound reference to access the PyAny
-        let py_any = int_rep.as_ref();
-        // Downcast the PyAny reference to PyLong
-        let py_long = py_any.downcast::<PyLong>().map_err(|_| pyo3::exceptions::PyTypeError::new_err("Expected a PyLong"))?.as_ref();
-
-        // Convert the PyLong into a BigInt using to_string
-        let big_int_str = py_long.str()?.to_str()?.to_owned();
-        
-        // Convert the string to a Rust BigInt (assumption is base-10)
-        let big_int = BigInt::parse_bytes(big_int_str.as_bytes(), 10)
-            .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("Failed to parse BigInt"))?;
-
-        let test_wallet = wallet_from_int(network, big_int)?;
-        Ok(test_wallet)
-   })
 }
 
 /// A Python module for interacting with the Rust chain-gang BSV script interpreter
@@ -218,7 +202,6 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_wif_to_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(py_bytes_to_wif, m)?)?;
     m.add_function(wrap_pyfunction!(py_generate_wif_from_pw_nonce, m)?)?;
-    m.add_function(wrap_pyfunction!(py_wallet_from_int, m)?)?;
     // Script
     m.add_class::<PyScript>()?;
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -191,6 +191,7 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_sig_hash_preimage, m)?)?;
     m.add_function(wrap_pyfunction!(py_sig_hash, m)?)?;
     m.add_function(wrap_pyfunction!(py_wif_to_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bytes_to_wif, m)?)?;
     // Script
     m.add_class::<PyScript>()?;
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -192,6 +192,7 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_sig_hash, m)?)?;
     m.add_function(wrap_pyfunction!(py_wif_to_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(py_bytes_to_wif, m)?)?;
+    m.add_function(wrap_pyfunction!(py_generate_wif_from_pw_nonce, m)?)?;
     // Script
     m.add_class::<PyScript>()?;
 

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -394,7 +394,7 @@ impl PyWallet {
     }
 
     #[classmethod]
-    fn create_wallet_from_bytes(_cls: &Bound<'_, PyType>, network: &str, key_bytes: &[u8]) -> PyResult<Self>{
+    fn wallet_from_bytes(_cls: &Bound<'_, PyType>, network: &str, key_bytes: &[u8]) -> PyResult<Self>{
         if let Some(netwrk) = str_to_network(network){
             // Ensure the length of key_bytes is 32 bytes
             if key_bytes.len() != 32 {

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -174,7 +174,6 @@ pub fn str_to_network(network: &str) -> Option<Network> {
     }
 }
 
-
 /// This class represents the Wallet functionality,
 /// including handling of Private and Public keys
 /// and signing transactions

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -174,6 +174,7 @@ pub fn str_to_network(network: &str) -> Option<Network> {
     }
 }
 
+
 /// This class represents the Wallet functionality,
 /// including handling of Private and Public keys
 /// and signing transactions


### PR DESCRIPTION
A pull request to add wallet features and functions required to support wild-bit-tool (formerly called BBT). Please refer to JIRA RPT-140 for a description. 

The functions added are: 

wif_to_bytes & bytes_to_wif (for private keys).
Creating a py_wallet from integers, hex strings or bytes
Return the scalar value from py_wallet in integer, hex string or bytes format
Generate an key in WIF format given a password string and nonce value
