### PR TITLE
59 whatsonchain api erros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ byteorder = "1.2"
 dns-lookup = "2.0.4"
 hex = "0.4.3"
 linked-hash-map = "0.5"
-log = { version = "0.4.26", features = ["max_level_trace", "release_max_level_warn"] }
+log = { version = "0.4.27", features = ["max_level_trace", "release_max_level_warn"] }
 db-key = "0.0.5"
 thiserror = "2.0.12"
 url = "2.5.4"
@@ -37,12 +37,12 @@ pbkdf2 = "0.12.2"
 # Used by the interface feature
 serde = { version = "1.0.219", features = ["derive"], optional = true }
 serde_json = { version = "1.0.140", optional = true }
-reqwest = { version = "0.12.13", features = ["json"], optional = true }
-async-mutex = { version = "1.4.0", optional = true }
-async-trait = { version = "0.1.87", optional = true }
+reqwest = { version = "0.12.15", features = ["json"], optional = true }
+async-mutex = { version = "1.4.1", optional = true }
+async-trait = { version = "0.1.88", optional = true }
 
 # For python feature
-pyo3 = { version = "0.24.0", optional = true }
+pyo3 = { version = "0.24.2", optional = true }
 regex = "^1.5.5"
 lazy_static = "1.5.0"
 rand_core = "0.9.3"

--- a/python/src/tests/test_woc.py
+++ b/python/src/tests/test_woc.py
@@ -117,6 +117,19 @@ class WoCTests(unittest.TestCase):
             else:
                 self.assertEqual(result[k], v)
 
+    def test_get_merkle_proof(self):
+        block_hash = ""
+        txid = "6106903f0e8e905b749b73d2a7239a22d2f06faf95f66e2ee4db77d875bf7bea"
+        result = self.woc_interface.get_merkle_proof(block_hash, txid)
+        assert result is not None
+        expected_result = [{
+            'index': 3,
+            'txOrId': '6106903f0e8e905b749b73d2a7239a22d2f06faf95f66e2ee4db77d875bf7bea',
+            'target': '0000000011eb7961f5b07c64f130c19eb0e1c61a1273d5774eff54f72a847d14',
+            'nodes': ['d947f541793cccf9a43463d21a1318f99144a2a7ee4b41fd36c74dfe87df065a', '8205865d2b22f2a83367dd338498d7bf41c0a7cf3eedcfb0579885cb98a767d1']
+        }]
+        self.assertEqual(result, expected_result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_woc.py
+++ b/python/src/tests/test_woc.py
@@ -1,0 +1,122 @@
+""" Test of WhatsOnChain API calls
+"""
+import unittest
+from tx_engine import interface_factory
+
+
+CONFIG = {
+    "interface_type": "woc",
+    "network_type": "testnet",
+}
+
+
+class WoCTests(unittest.TestCase):
+    """ Tests of WhatsOnChain API calls
+    """
+    def setUp(self):
+        self.woc_interface = interface_factory.set_config(CONFIG)
+        self.maxDiff = 4096
+        return super().setUp()
+
+    def test_get_block_header(self):
+        block_hash = "000000001a06963e6bc2bd798fa848e57856b9239c22feba644ec100dc809fe4"
+        result = self.woc_interface.get_block_header(block_hash)
+        assert result is not None
+        expected_result = {
+            'hash': '000000001a06963e6bc2bd798fa848e57856b9239c22feba644ec100dc809fe4',
+            # 'confirmations': 8,
+            'size': 184,
+            'height': 1671921,
+            'version': 536870912,
+            'versionHex': '20000000',
+            'merkleroot': '998b84019194d5dc5a505997dc17554bb398ac026e4d1fd023571a1d76e3fb63',
+            'time': 1745842569,
+            'mediantime': 1745839474,
+            'nonce': 3248024860,
+            'bits': '1c5abd74',
+            'difficulty': 2.82120287754299,
+            'chainwork': '00000000000000000000000000000000000000000000015814b6013f8e293653',
+            'previousblockhash': '00000000122ac20c9fcf1d9f5dca32f8466215a2ef87efb86d9efd1cd0010a88',
+            'nextblockhash': '000000001a704a33a4a82cf348b1ffe4403e49f1e2368897712745fabfaf0182',
+            'nTx': 0,
+            'num_tx': 1
+        }
+        # Check all fields except `confirmations` which will change
+        for k, v in expected_result.items():
+            self.assertEqual(result[k], v)
+
+    def test_get_block(self):
+        block_hash = "000000001a06963e6bc2bd798fa848e57856b9239c22feba644ec100dc809fe4"
+        result = self.woc_interface.get_block(block_hash)
+        assert result is not None
+        expected_result = {
+            'hash': '000000001a06963e6bc2bd798fa848e57856b9239c22feba644ec100dc809fe4',
+            # 'confirmations': 9,
+            'size': 184,
+            'height': 1671921,
+            'version': 536870912,
+            'versionHex': '20000000',
+            'merkleroot': '998b84019194d5dc5a505997dc17554bb398ac026e4d1fd023571a1d76e3fb63',
+            'txcount': 1,
+            'nTx': 0,
+            'num_tx': 1,
+            'tx': ['998b84019194d5dc5a505997dc17554bb398ac026e4d1fd023571a1d76e3fb63'],
+            'time': 1745842569,
+            'mediantime': 1745839474,
+            'nonce': 3248024860,
+            'bits': '1c5abd74',
+            'difficulty': 2.82120287754299,
+            'chainwork': '00000000000000000000000000000000000000000000015814b6013f8e293653',
+            'previousblockhash': '00000000122ac20c9fcf1d9f5dca32f8466215a2ef87efb86d9efd1cd0010a88',
+            'nextblockhash': '000000001a704a33a4a82cf348b1ffe4403e49f1e2368897712745fabfaf0182',
+            'coinbaseTx': {
+                'txid': '998b84019194d5dc5a505997dc17554bb398ac026e4d1fd023571a1d76e3fb63',
+                'hash': '998b84019194d5dc5a505997dc17554bb398ac026e4d1fd023571a1d76e3fb63',
+                'version': 1,
+                'size': 103,
+                'locktime': 0,
+                'vin': [{
+                    'coinbase': '03f182190d546573746e6574204d696e6572',
+                    'txid': '',
+                    'vout': 0,
+                    'scriptSig': {
+                        'asm': '',
+                        'hex': ''
+                    },
+                    'sequence': 4294967295
+                }],
+                'vout': [{
+                    'value': 0.390625,
+                    'n': 0,
+                    'scriptPubKey': {
+                        'asm': 'OP_DUP OP_HASH160 0e84c845ae3af3ba20e8da29a4827abe93b639a4 OP_EQUALVERIFY OP_CHECKSIG',
+                        'hex': '76a9140e84c845ae3af3ba20e8da29a4827abe93b639a488ac',
+                        'reqSigs': 1,
+                        'type': 'pubkeyhash',
+                        'addresses': ['mgqipciCS56nCYSjB1vTcDGskN82yxfo1G'],
+                        'isTruncated': False
+                    }
+                }],
+                'blockhash': '000000001a06963e6bc2bd798fa848e57856b9239c22feba644ec100dc809fe4',
+                # 'confirmations': 9,
+                'time': 1745842569,
+                'blocktime': 1745842569,
+                'blockheight': 1671921
+            },
+            'totalFees': 0,
+            'miner': '\x03��\x19\rTestnet Miner',
+            'pages': None
+        }
+
+        # Check all fields except `confirmations` which will change
+        # Note dictionary can have dictionary..
+        for k, v in expected_result.items():
+            if isinstance(v, dict):
+                for k1, v1 in v.items():
+                    self.assertEqual(result[k][k1], v1)
+            else:
+                self.assertEqual(result[k], v)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/tx_engine/interface/woc.py
+++ b/python/src/tx_engine/interface/woc.py
@@ -103,7 +103,7 @@ def get_chain_info(testnet: bool = True):
 def get_merkle_proof(tx_id: str, testnet: bool = True):
     """ This endpoint retrieves the merkle tree info for a given confirmed tx
     """
-    return get_response(f"{get_url(testnet)}/tx/{tx_id}/proof")
+    return get_response(f"{get_url(testnet)}/tx/{tx_id}/proof/tsc")
 
 
 def broadcast_tx(transaction: str, testnet: bool = True):

--- a/python/src/tx_engine/interface/woc.py
+++ b/python/src/tx_engine/interface/woc.py
@@ -123,4 +123,4 @@ def get_block_by_hash(block_hash: str, testnet: bool = True):
 def get_block_header(block_hash: str, testnet: bool = True) -> Dict:
     """ Get a blockheader by hash
     """
-    return get_response(f"{get_url(testnet)}/block/hash/{block_hash}/header")
+    return get_response(f"{get_url(testnet)}/block/{block_hash}/header")

--- a/src/messages/merkle_block.rs
+++ b/src/messages/merkle_block.rs
@@ -35,7 +35,7 @@ impl MerkleBlock {
         let mut row_len = self.total_transactions as usize;
         let mut total_nodes = row_len;
         while row_len > 1 {
-            row_len = (row_len + 1) / 2;
+            row_len = row_len.div_ceil(2);
             total_nodes += row_len;
         }
 
@@ -61,7 +61,7 @@ impl MerkleBlock {
             return Err(ChainGangError::BadData("Not all nodes consumed".to_string()));
         }
 
-        if (flag_bits_used + 7) / 8 < self.flags.len() {
+        if flag_bits_used.div_ceil(8) < self.flags.len() {
             return Err(ChainGangError::BadData("Not all flag bits consumed".to_string()));
         }
 

--- a/src/script/interpreter.rs
+++ b/src/script/interpreter.rs
@@ -595,7 +595,7 @@ pub fn core_eval<T: Checker>(
                 }
                 // Add zeros
                 let diff = m.to_usize().unwrap() - n.len();
-                v.extend(std::iter::repeat(0).take(diff));
+                v.extend(std::iter::repeat_n(0, diff));
                 // Prepend the value
                 for b in n.iter().rev() {
                     v.insert(0, *b);

--- a/src/util/bits.rs
+++ b/src/util/bits.rs
@@ -32,7 +32,7 @@ impl Bits {
         let mut vec = data.to_vec();
         let len = min(data.len() * 8, len);
         if len > vec.len() * 8 {
-            vec.truncate((len + 7) / 8);
+            vec.truncate(len.div_ceil(8));
         }
         let rem = (len % 8) as u8;
         if rem != 0 {
@@ -76,7 +76,7 @@ impl Bits {
         let end = i + len;
         let mut curr: u64 = 0;
         let mut i = i;
-        for j in i / 8..((i + len + 7) / 8) {
+        for j in i / 8..(i + len).div_ceil(8) {
             let b_len = min(end - i, 8 - (i - j * 8));
             curr = (curr << b_len) | self.extract_byte(i, b_len) as u64;
             i += b_len;

--- a/src/util/rx.rs
+++ b/src/util/rx.rs
@@ -74,7 +74,7 @@ impl<T> Observer<T> for Subject<T> {
             observers.retain(|observer| observer.upgrade().is_some());
         }
 
-        let any_pending = { self.pending.read().unwrap().len() > 0 };
+        let any_pending = { !self.pending.read().unwrap().is_empty() };
         if any_pending {
             let mut observers = self.observers.write().unwrap();
             let mut pending = self.pending.write().unwrap();

--- a/src/wallet/mnemonic.rs
+++ b/src/wallet/mnemonic.rs
@@ -44,7 +44,7 @@ fn load_wordlist_internal(bytes: &[u8]) -> Vec<String> {
 pub fn mnemonic_encode(data: &[u8], word_list: &[String]) -> Vec<String> {
     let hash = Sha256::digest(data);
 
-    let mut words = Vec::with_capacity((data.len() * 8 + data.len() / 32 + 10) / 11);
+    let mut words = Vec::with_capacity((data.len() * 8 + data.len() / 32).div_ceil(11));
     let mut bits = Bits::from_slice(data, data.len() * 8);
     bits.append(&Bits::from_slice(hash.as_ref(), data.len() / 4));
     for i in 0..bits.len / 11 {


### PR DESCRIPTION
* Clippy and Cargo updates
* Added Python tests for WoC interface.
* Fixed `get_block_header` to use new endpoint
* Updated `get_merkle_proof` to use new tsc endpoint

Spoke with WoC product manager about versioning REST API changes.