### PR TITLE
Fix deprecated GenericArray::as_slice in extended_key derivation

### DIFF
--- a/src/wallet/extended_key.rs
+++ b/src/wallet/extended_key.rs
@@ -316,8 +316,7 @@ impl ExtendedKey {
 
         //let child_private_key =
         //    unsafe { slice::from_raw_parts(secp_child_secret_key.as_ptr(), 32) };
-        let child_bytes = child_sk.to_bytes();
-        let child_private_key = child_bytes.as_slice();
+        let child_private_key: [u8; 32] = child_sk.to_bytes().into();
 
         let child_chain_code = &hmac[32..];
         let fingerprint = self.fingerprint()?;
@@ -328,7 +327,7 @@ impl ExtendedKey {
             &fingerprint,
             index,
             child_chain_code,
-            child_private_key,
+            &child_private_key,
         )
     }
 


### PR DESCRIPTION
## Summary
- Replace deprecated `GenericArray::as_slice()` with `.into()` when converting child scalar bytes during BIP-32 private key derivation
- Aligns with the existing pattern in `wallet.rs` and removes the build warning in `extended_key.rs`

## Test plan
- [x] `cargo build --release` (no warnings from `extended_key.rs`)
- [x] `cargo test wallet::extended_key --release` (6 tests pass)


Made with [Cursor](https://cursor.com)