### PR TITLE
Bump Rust and Python dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-byteorder = "1.2"
+byteorder = "1.5"
 dns-lookup = "3.0.1"
 hex = "0.4.3"
 linked-hash-map = "0.5"
 log = { version = "0.4.29", features = ["max_level_trace", "release_max_level_warn"] }
 db-key = "0.0.5"  # this is a non-trival update
-thiserror = "2.0.17"
+thiserror = "2.0.18"
 url = "2.5.8"
 
 
@@ -23,7 +23,7 @@ url = "2.5.8"
 murmur3 = "0.5.2"
 num-bigint = "0.4.6"
 num-traits = "0.2"
-rand = "0.8.5"  # Don't bump this unless k256 is updated 
+rand = "0.8.6"  # Don't bump this unless k256 is updated 
 ripemd = "0.1.3"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
@@ -36,17 +36,17 @@ pbkdf2 = "0.12.2"
 
 # Used by the interface feature
 serde = { version = "1.0.228", features = ["derive"], optional = true }
-serde_json = { version = "1.0.149", optional = true }
-reqwest = { version = "0.13.1", features = ["json"], optional = true }
+serde_json = { version = "1.0.150", optional = true }
+reqwest = { version = "0.13.3", features = ["json"], optional = true }
 async-mutex = { version = "1.4.1", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 
 # For python feature
 pyo3 = { version = "0.27.2", optional = true }
-regex = "^1.12.2"
+regex = "^1.12.3"
 lazy_static = "1.5.0"
 rand_core = "0.9.5"
-typenum = "1.19.0"
+typenum = "1.20.0"
 
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-dependencies = ["requests==2.33.0", "python-bitcoinrpc==1.0", "cryptography==46.0.7"]
+dependencies = ["requests==2.34.2", "python-bitcoinrpc==1.0", "cryptography==48.0.0"]
 
 [tool.maturin]
 features = ["pyo3/extension-module", "python"]


### PR DESCRIPTION
## Summary
- Bump compatible Rust dependencies: byteorder, thiserror, rand (0.8.6), serde_json, reqwest, regex, typenum
- Update Python dependencies: requests 2.34.2, cryptography 48.0.0
- Leave major-version upgrades unchanged (pyo3, db-key, sha2/hmac/pbkdf2, rand beyond 0.8.x pending k256)

## Test plan
- [x] `cargo test --all-features` (130 tests pass)
- [x] `maturin build --release`
- [x] `python/tests.sh` (173 tests pass with updated Python deps)


Made with [Cursor](https://cursor.com)