### PR TITLE
Allow Chronicle high-S signatures (Phase 2)

### DIFF
--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -23,10 +23,27 @@ Constants in Rust: `SIGHASH_CHRONICLE = 0x20` in `src/transaction/sighash.rs`.
 
 Python: `SIGHASH.CHRONICLE` and `SIGHASH.ALL_FORKID_CHRONICLE` in `python/src/tx_engine/tx/sighash.py`.
 
+## Signing (low-S policy)
+
+Per the Chronicle spec, the low-S requirement is removed for transactions with `version > 1`. For signing:
+
+| Flags | Behavior |
+|-------|----------|
+| Without `SIGHASH_CHRONICLE` | Signatures are normalized to low-S (BIP146) |
+| With `SIGHASH_CHRONICLE` | Raw signer output is preserved (high-S allowed) |
+
+Rust: `uses_low_s_signing()` and `generate_signature()` in `src/transaction/mod.rs`.
+
+Note: k256's deterministic signer currently returns low-S; the Chronicle path matters when encoding externally produced signatures or future signing backends.
+
+Verification for `tx.version > 1` normalizes S before the k256 prehash verify call so high-S encodings are accepted under Chronicle rules.
+
 ## Implementation status
 
 - [x] OTDA sighash routing (`SIGHASH_CHRONICLE`)
 - [x] OTDA preimage for Chronicle signatures
+- [x] Optional high-S signing when `SIGHASH_CHRONICLE` is set
+- [x] High-S acceptance during script verification for `tx.version > 1`
 - [ ] Chronicle opcodes (OP_VER, OP_SUBSTR, etc.)
 - [ ] Version-gated malleability relaxation (`tx.version > 1`)
 - [ ] Two-phase unlock/lock script evaluation

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -165,7 +165,11 @@ impl Checker for TransactionChecker<'_> {
         )?;
         let der_sig = &sig[0..sig.len() - 1];
 
-        let signature = Signature::from_der(der_sig)?;
+        let mut signature = Signature::from_der(der_sig)?;
+        if self.tx.version > 1 {
+            // Chronicle lifts the low-S rule; normalize so k256 accepts high-S encodings.
+            signature = signature.normalize_s().unwrap_or(signature);
+        }
         let message = sig_hash.0;
         let verifying_key: VerifyingKey = VerifyingKey::from_sec1_bytes(pubkey)?;
         Ok(verifying_key.verify_prehash(&message, &signature).is_ok())
@@ -240,11 +244,98 @@ mod tests {
     use crate::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID};
     use crate::util::hash160;
     use k256::ecdsa::{SigningKey, VerifyingKey};
+    use k256::ecdsa::signature::hazmat::PrehashSigner;
+    use k256::ecdsa::signature::SignatureEncoding;
 
     #[test]
     fn standard_p2pkh() {
         standard_p2pkh_test(SIGHASH_ALL);
         standard_p2pkh_test(SIGHASH_ALL | SIGHASH_FORKID);
+    }
+
+    #[test]
+    fn chronicle_high_s_signature_verifies() {
+        use crate::transaction::sighash::SIGHASH_CHRONICLE;
+        use k256::ecdsa::Signature;
+        use num_bigint::BigUint;
+
+        const SECP256K1_N: &str =
+            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141";
+
+        let private_key = [2; 32];
+        let secret_key = SigningKey::from_slice(&private_key).unwrap();
+        let verifying_key = secret_key.verifying_key();
+        let pk = verifying_key_as_bytes(verifying_key);
+        let pkh = hash160(&pk);
+
+        let mut lock_script = Script::new();
+        lock_script.append(OP_DUP);
+        lock_script.append(OP_HASH160);
+        lock_script.append_data(&pkh.0);
+        lock_script.append(OP_EQUALVERIFY);
+        lock_script.append(OP_CHECKSIG);
+
+        let tx_1 = Tx {
+            version: 2,
+            inputs: vec![],
+            outputs: vec![TxOut {
+                satoshis: 10,
+                lock_script,
+            }],
+            lock_time: 0,
+        };
+
+        let mut tx_2 = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                prev_output: OutPoint {
+                    hash: tx_1.hash(),
+                    index: 0,
+                },
+                unlock_script: Script(vec![]),
+                sequence: 0xffffffff,
+            }],
+            outputs: vec![],
+            lock_time: 0,
+        };
+
+        let sighash_type = SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE;
+        let mut cache = SigHashCache::new();
+        let lock_script = &tx_1.outputs[0].lock_script.0;
+        let sig_hash = sighash(&tx_2, 0, lock_script, 10, sighash_type, &mut cache).unwrap();
+
+        let low_sig: Signature = secret_key.sign_prehash(&sig_hash.0).unwrap();
+        let compact = low_sig.to_bytes();
+        let n = BigUint::parse_bytes(SECP256K1_N.as_bytes(), 16).unwrap();
+        let s = BigUint::from_bytes_be(&compact[32..]);
+        let high_s = &n - &s;
+        let mut high_compact = compact;
+        let high_s_bytes = high_s.to_bytes_be();
+        high_compact[64 - high_s_bytes.len()..].copy_from_slice(&high_s_bytes);
+        let high_sig = Signature::try_from(high_compact.as_ref()).unwrap();
+
+        let mut sig = high_sig.to_der().to_vec();
+        sig.push(sighash_type);
+
+        let mut unlock_script = Script::new();
+        unlock_script.append_data(&sig);
+        unlock_script.append_data(&pk);
+        tx_2.inputs[0].unlock_script = unlock_script;
+
+        let mut cache = SigHashCache::new();
+        let mut c = TransactionChecker {
+            tx: &tx_2,
+            sig_hash_cache: &mut cache,
+            input: 0,
+            satoshis: 10,
+            require_sighash_forkid: true,
+        };
+
+        let mut script = Script::new();
+        script.append_slice(&tx_2.inputs[0].unlock_script.0);
+        script.append(OP_CODESEPARATOR);
+        script.append_slice(&tx_1.outputs[0].lock_script.0);
+        assert!(script.eval(&mut c, NO_FLAGS).is_ok());
     }
 
     fn verifying_key_as_bytes(verifying_key: &VerifyingKey) -> [u8; 33] {

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -38,20 +38,161 @@ use k256::ecdsa::{
 pub mod p2pkh;
 pub mod sighash;
 
+/// Returns true when low-S normalization should be applied before encoding a signature.
+///
+/// Chronicle signatures (`SIGHASH_CHRONICLE`) may use high-S values per the Chronicle spec.
+pub fn uses_low_s_signing(sighash_type: u8) -> bool {
+    sighash_type & sighash::SIGHASH_CHRONICLE == 0
+}
+
+/// Applies low-S normalization policy and appends the sighash type byte.
+fn encode_signature(signature: Signature, sighash_type: u8) -> Vec<u8> {
+    let signature = if uses_low_s_signing(sighash_type) {
+        signature.normalize_s().unwrap_or(signature)
+    } else {
+        signature
+    };
+    let mut sig = signature.to_der().to_vec();
+    sig.push(sighash_type);
+    sig
+}
+
 /// Generates a signature for a transaction sighash
 pub fn generate_signature(
     private_key: &[u8; 32],
     sighash: &Hash256,
     sighash_type: u8,
 ) -> Result<Vec<u8>, ChainGangError> {
-    let message = sighash.0;
-
     let signing_key = SigningKey::from_slice(private_key)?;
-    let signature: Signature = signing_key.sign_prehash(&message)?;
-    let signature = signature.normalize_s().unwrap_or(signature);
-    let sig_der = signature.to_der();
-    let mut sig = sig_der.to_vec();
-
-    sig.push(sighash_type);
-    Ok(sig)
+    let signature: Signature = signing_key.sign_prehash(&sighash.0)?;
+    Ok(encode_signature(signature, sighash_type))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transaction::sighash::{SIGHASH_ALL, SIGHASH_CHRONICLE, SIGHASH_FORKID};
+    use k256::ecdsa::SigningKey;
+    use num_bigint::BigUint;
+
+    const SECP256K1_N: &str =
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141";
+
+    fn signature_has_high_s(der: &[u8]) -> bool {
+        let sig = Signature::from_der(der).unwrap();
+        sig.normalize_s()
+            .map(|normalized| normalized != sig)
+            .unwrap_or(false)
+    }
+
+    fn flip_der_to_high_s(der: &[u8]) -> Vec<u8> {
+        let sig = Signature::from_der(der).unwrap();
+        let low_s = sig.normalize_s().unwrap_or(sig);
+        assert!(
+            !signature_has_high_s(low_s.to_der().as_bytes()),
+            "expected low-S input for flip helper"
+        );
+
+        let compact = low_s.to_bytes();
+        let n = BigUint::parse_bytes(SECP256K1_N.as_bytes(), 16).unwrap();
+        let s = BigUint::from_bytes_be(&compact[32..]);
+        let high_s = &n - &s;
+        assert!(high_s > n >> 1);
+
+        let mut high_compact = compact;
+        let high_s_bytes = high_s.to_bytes_be();
+        high_compact[64 - high_s_bytes.len()..].copy_from_slice(&high_s_bytes);
+        let high_sig = Signature::try_from(high_compact.as_ref()).unwrap();
+        assert!(signature_has_high_s(high_sig.to_der().as_bytes()));
+        high_sig.to_der().to_vec()
+    }
+
+    #[test]
+    fn uses_low_s_signing_without_chronicle() {
+        assert!(uses_low_s_signing(SIGHASH_ALL | SIGHASH_FORKID));
+    }
+
+    #[test]
+    fn uses_low_s_signing_disabled_with_chronicle() {
+        assert!(!uses_low_s_signing(
+            SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE
+        ));
+    }
+
+    #[test]
+    fn generate_signature_without_chronicle_is_low_s() {
+        let key = [2u8; 32];
+        let sighash = Hash256([3u8; 32]);
+        let sig = generate_signature(&key, &sighash, SIGHASH_ALL | SIGHASH_FORKID).unwrap();
+        assert!(!signature_has_high_s(&sig[..sig.len() - 1]));
+    }
+
+    #[test]
+    fn encode_signature_normalizes_high_s_without_chronicle() {
+        let key = [2u8; 32];
+        let sighash = Hash256([3u8; 32]);
+        let signing_key = SigningKey::from_slice(&key).unwrap();
+        let raw: Signature = signing_key.sign_prehash(&sighash.0).unwrap();
+        let high_s = Signature::from_der(flip_der_to_high_s(raw.to_der().as_bytes()).as_slice()).unwrap();
+
+        let encoded = encode_signature(high_s, SIGHASH_ALL | SIGHASH_FORKID);
+        assert!(!signature_has_high_s(&encoded[..encoded.len() - 1]));
+    }
+
+    #[test]
+    fn encode_signature_preserves_high_s_with_chronicle() {
+        let key = [2u8; 32];
+        let sighash = Hash256([3u8; 32]);
+        let signing_key = SigningKey::from_slice(&key).unwrap();
+        let raw: Signature = signing_key.sign_prehash(&sighash.0).unwrap();
+        let high_s = Signature::from_der(flip_der_to_high_s(raw.to_der().as_bytes()).as_slice()).unwrap();
+
+        let encoded = encode_signature(high_s, SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE);
+        assert!(signature_has_high_s(&encoded[..encoded.len() - 1]));
+    }
+
+    #[test]
+    fn high_s_ecdsa_verifies_with_k256() {
+        use k256::ecdsa::signature::hazmat::PrehashVerifier;
+        let key = [2u8; 32];
+        let sighash = Hash256([3u8; 32]);
+        let signing_key = SigningKey::from_slice(&key).unwrap();
+        let raw: Signature = signing_key.sign_prehash(&sighash.0).unwrap();
+        let high_s =
+            Signature::from_der(flip_der_to_high_s(raw.to_der().as_bytes()).as_slice()).unwrap();
+        let normalized = high_s.normalize_s().unwrap();
+        assert_eq!(normalized, raw);
+        assert!(
+            signing_key
+                .verifying_key()
+                .verify_prehash(&sighash.0, &normalized)
+                .is_ok()
+        );
+        // k256 rejects non-normalized S at verify time; Chronicle nodes accept high-S
+        // by verifying the equivalent normalized signature.
+        assert!(
+            signing_key
+                .verifying_key()
+                .verify_prehash(&sighash.0, &high_s)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn generate_signature_chronicle_uses_raw_signer_output() {
+        let key = [2u8; 32];
+        let sighash = Hash256([3u8; 32]);
+        let signing_key = SigningKey::from_slice(&key).unwrap();
+        let raw: Signature = signing_key.sign_prehash(&sighash.0).unwrap();
+        let chronicle = generate_signature(
+            &key,
+            &sighash,
+            SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE,
+        )
+        .unwrap();
+        let mut expected = raw.to_der().to_vec();
+        expected.push(SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE);
+        assert_eq!(chronicle, expected);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Skip low-S normalization in `generate_signature()` when `SIGHASH_CHRONICLE` is set
- Accept high-S CHECKSIG encodings on `tx.version > 1` by normalizing before k256 verify
- Add unit and integration tests for signing policy and script verification

Depends on #85 (Phase 0 OTDA sighash routing).

## Test plan
- [x] `cargo test --all-features --lib` (141 tests)
- [x] `./python/tests.sh` (174 tests)
- [x] New tests: `uses_low_s_signing_*`, `encode_signature_*`, `chronicle_high_s_signature_verifies`


Made with [Cursor](https://cursor.com)