### PR TITLE
Raise Chronicle script number limit to 32 MB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ crate-type = ["cdylib", "lib"]
 opt-level = "s"     # Optimize for size over speed
 lto = true          # Enable link-time optimizations to shrink binary
 
-["features"]
+[features]
 default = ["dep:serde", "dep:serde_json"]
 interface = ["dep:serde", "dep:serde_json", "dep:reqwest", "dep:async-mutex", "dep:async-trait"]
 python = ["dep:serde", "dep:serde_json", "dep:pyo3"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This library provides a Python interface for building BitcoinSV scripts and tran
 
 For documentation of the Python Classes see below.
 
+## Chronicle upgrade
+
+Bitcoin SV [Chronicle](https://docs.bsvblockchain.org/network-topology/nodes/sv-node/chronicle-release) support is implemented in the Rust library (`chain-gang`). See [docs/Chronicle.md](docs/Chronicle.md) for sighash routing, opcodes, two-phase script evaluation, malleability rules, and script number limits.
+
+Chronicle behavior is gated on **`tx.version > 1`** when validating transactions in Rust (`Tx.validate`). Use `version: 2` (or higher) on spending transactions to opt in.
+
+**Python `Context` debugger:** stepping scripts via `Context` uses the legacy single-script evaluator without transaction version. It does not perform two-phase unlock/lock evaluation or version-gated malleability rules. For Chronicle-accurate validation, use Rust `Tx.validate` or build unlock/lock scripts explicitly. `OP_VER` and related opcodes require a transaction version and will fail in `Context` unless a version-aware checker is added.
+
 # Python Installation
 As this library is hosted on PyPi (https://pypi.org/project/tx-engine/) and is installed using:
 
@@ -105,6 +113,9 @@ Context has the following methods:
 * `__init__(self, script: Script, cmds: Commands = None, ip_limit: int , z: bytes)` - constructor
 * `evaluate_core(self, quiet: bool = False) -> bool` - evaluates the script/cmds using the the interpreter and returns the stacks (`tack`, `alt_stack`). if quiet is true, dont print exceptions
 * `evaluate(self, quiet: bool = False) -> bool` - executes the script and decode stack elements to numbers (`stack`, `alt_stack`). Checks `stack` is true on return. if quiet is true, dont print exceptions.
+
+Note: `evaluate` / `evaluate_core` use the legacy debugger path (see [Chronicle upgrade](#chronicle-upgrade)). They do not apply Chronicle two-phase eval or version-gated malleability rules.
+
 * `get_stack(self) -> Stack` - Return the `stack` as human readable
 * `get_altstack(self) -> Stack`-  Return the `alt_stack` as human readable
 * `set_ip_start(self, start: int)` - sets the start location for the intepreter. 

--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -87,6 +87,14 @@ Rules apply when the checker provides a transaction version (`TransactionChecker
 
 Rust: `uses_relaxed_malleability()`, `is_push_only()` in `src/script/interpreter.rs`.
 
+## Script number limit
+
+The maximum encoded script number size increases from 750 KB to 32 MB for Chronicle transactions (`tx.version > 1`). Pre-genesis inputs (`PREGENESIS_RULES`) keep the 4-byte limit; post-genesis `version == 1` transactions keep 750 KB.
+
+Rust: `max_script_num_length()`, `MAX_SCRIPT_NUM_LENGTH_*` in `src/script/stack.rs`; enforced in `core_eval()` via `pop_bigint_checked()` and `OP_BIN2NUM` / `OP_NUM2BIN`.
+
+Python: `MAX_SCRIPT_NUM_LENGTH_CHRONICLE` in `python/src/tx_engine/engine/util.py`.
+
 ## Implementation status
 
 - [x] OTDA sighash routing (`SIGHASH_CHRONICLE`)
@@ -96,7 +104,7 @@ Rust: `uses_relaxed_malleability()`, `is_push_only()` in `src/script/interpreter
 - [x] Chronicle opcodes (OP_VER, OP_SUBSTR, OP_LEFT, OP_RIGHT, OP_LSHIFTNUM, OP_RSHIFTNUM)
 - [x] Two-phase unlock/lock script evaluation (`tx.version > 1`)
 - [x] Version-gated malleability relaxation (`tx.version > 1`)
-- [ ] 32 MB script number limit
+- [x] 32 MB script number limit (`tx.version > 1`)
 
 ## References
 

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -23,6 +23,7 @@ BSV only Features
 * Wallet key derivation and mnemonic parsing
 * Various Bitcoin primitives
 * Genesis upgrade support
+* [Chronicle upgrade](Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules)
 
 `Chain-gang` is based on `Rust-SV` An open source library to build Bitcoin SV applications and infrastructure in Rust. The documentation for `Rust-SV` can be found here: 
 [Rust-SV Documentation](https://docs.rs/sv/)

--- a/python/src/tests/test_debug.py
+++ b/python/src/tests/test_debug.py
@@ -34,6 +34,16 @@ class DebugTest(unittest.TestCase):
         self.assertTrue(context.evaluate())
         self.assertEqual(context.get_stack(), Stack([[1], [2], [3]]))
 
+    def test_ip_limit_with_z_matches_without_z(self):
+        """Regression: py_script_eval_pystack must pass start_at/break_at consistently when z is set."""
+        script = Script([OP_1, OP_2, OP_3, OP_4])
+        z = bytes(32)
+        without_z = Context(script=script, ip_limit=2)
+        with_z = Context(script=script, ip_limit=2, z=z)
+        self.assertTrue(without_z.evaluate_core())
+        self.assertTrue(with_z.evaluate_core())
+        self.assertEqual(without_z.get_stack(), with_z.get_stack())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tx_engine/engine/context.py
+++ b/python/src/tx_engine/engine/context.py
@@ -39,8 +39,10 @@ class Context:
         self.alt_stack = Stack()
 
     def evaluate_core(self, quiet: bool = False) -> bool:
-        """ evaluate_core calls the interpreter and returns the stacks
-            if quiet is true, dont print exceptions
+        """Evaluate script opcodes and update stack/alt_stack.
+
+        Uses the legacy single-phase evaluator without transaction version.
+        For Chronicle rules (two-phase eval, malleability), use Rust Tx.validate.
         """
 
         try:

--- a/python/src/tx_engine/engine/util.py
+++ b/python/src/tx_engine/engine/util.py
@@ -6,9 +6,11 @@ from .engine_types import StackElement
 
 # Maximum script number length before Genesis (equal to CScriptNum::MAXIMUM_ELEMENT_SIZE)
 MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS: Final = 4
-# Maximum script number length after Genesis
+# Maximum script number length after Genesis (750 KB)
 MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS: Final = 750 * 1000
-# Maximum size that we are using
+# Maximum script number length after Chronicle (32 MB)
+MAX_SCRIPT_NUM_LENGTH_CHRONICLE: Final = 32 * 1024 * 1024
+# Maximum size that we are using for legacy callers
 MAXIMUM_ELEMENT_SIZE: Final = MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS
 
 # Curve constants

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -154,8 +154,8 @@ fn py_script_eval_pystack(
             script.eval_with_stack(
                 &mut ZChecker { z },
                 NO_FLAGS,
-                break_at,
                 start_at,
+                break_at,
                 main_stack,
                 alternative_stack,
             )?

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -95,23 +95,11 @@ impl Checker for ZChecker {
 
         let sig_hash = self.z;
         let der_sig = &sig[0..sig.len() - 1];
-        let signature = match Signature::from_der(der_sig) {
-            Ok(sig) => sig,
-            Err(e) => {
-                println!("Failed to parse the signature: {e}");
-                return Err(e.into()); // Return the error to the caller
-            }
-        };
+        let signature = Signature::from_der(der_sig)?;
 
         let message = sig_hash.0;
 
-        let verifying_key = match VerifyingKey::from_sec1_bytes(pubkey) {
-            Ok(verkey) => verkey,
-            Err(e) => {
-                println!("Failed to parse the public key {e}");
-                return Err(e.into());
-            }
-        };
+        let verifying_key = VerifyingKey::from_sec1_bytes(pubkey)?;
 
         Ok(verifying_key.verify_prehash(&message, &signature).is_ok())
     }

--- a/src/script/interpreter.rs
+++ b/src/script/interpreter.rs
@@ -1,7 +1,9 @@
 use crate::script::op_codes::*;
 use crate::script::stack::{
-    decode_bigint, decode_bool, encode_bigint, encode_num, is_minimally_encoded, pop_bigint,
-    pop_bool, pop_bool_minimal, pop_num_minimal, Stack,
+    check_script_num_length, decode_bigint, decode_bool, encode_bigint, encode_num,
+    is_minimally_encoded, pop_bigint_checked, pop_bool, pop_bool_minimal, pop_num_minimal,
+    push_bigint_checked, Stack, MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,
+    MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
 };
 use crate::script::Checker;
 use crate::transaction::sighash::SIGHASH_FORKID;
@@ -29,6 +31,19 @@ pub fn uses_two_phase_eval(tx_version: u32) -> bool {
 /// Whether malleability-related script rules are relaxed (Chronicle).
 pub fn uses_relaxed_malleability(tx_version: u32) -> bool {
     tx_version > 1
+}
+
+/// Maximum encoded script number length for the current evaluation context.
+pub fn max_script_num_length<T: Checker>(checker: &T, flags: u32) -> usize {
+    if flags & PREGENESIS_RULES != 0 {
+        return MAX_SCRIPT_NUM_LENGTH_PREGENESIS;
+    }
+    if let Ok(version) = checker.tx_version() {
+        if version as u32 > 1 {
+            return MAX_SCRIPT_NUM_LENGTH_CHRONICLE;
+        }
+    }
+    MAX_SCRIPT_NUM_LENGTH_GENESIS
 }
 
 /// True when the script contains only push operations.
@@ -242,6 +257,7 @@ pub fn core_eval<T: Checker>(
     let mut branch_exec: Vec<bool> = Vec::new();
     let mut check_index = 0;
     let mut i = start_at.unwrap_or(0);
+    let max_num_len = max_script_num_length(checker, flags);
 
     'outer: while i < script.len() {
         if !branch_exec.is_empty() && !branch_exec[branch_exec.len() - 1] {
@@ -343,11 +359,11 @@ pub fn core_eval<T: Checker>(
             OP_IF => branch_exec.push(pop_bool_for_if(&mut stack, checker)?),
             OP_NOTIF => branch_exec.push(!pop_bool_for_if(&mut stack, checker)?),
             OP_VERIF => {
-                let comparison = pop_bigint(&mut stack)?;
+                let comparison = pop_bigint_checked(&mut stack, max_num_len)?;
                 branch_exec.push(verif_branch_exec(checker, comparison, false)?);
             }
             OP_VERNOTIF => {
-                let comparison = pop_bigint(&mut stack)?;
+                let comparison = pop_bigint_checked(&mut stack, max_num_len)?;
                 branch_exec.push(verif_branch_exec(checker, comparison, true)?);
             }
             OP_ELSE => {
@@ -668,99 +684,99 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_1ADD => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 x += 1;
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_1SUB => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 x -= 1;
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_NEGATE => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 x = -x;
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_ABS => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x < BigInt::zero() {
                     x = -x;
                 }
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_NOT => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x == BigInt::zero() {
                     x = BigInt::one();
                 } else {
                     x = BigInt::zero();
                 }
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_0NOTEQUAL => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x == BigInt::zero() {
                     x = BigInt::zero();
                 } else {
                     x = BigInt::one();
                 }
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_ADD => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let sum = a + b;
-                stack.push(encode_bigint(sum));
+                push_bigint_checked(&mut stack, sum, max_num_len)?;
             }
             OP_SUB => {
-                let a = pop_bigint(&mut stack)?;
-                let b = pop_bigint(&mut stack)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
                 let difference = b - a;
-                stack.push(encode_bigint(difference));
+                push_bigint_checked(&mut stack, difference, max_num_len)?;
             }
             OP_MUL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let product = a * b;
-                stack.push(encode_bigint(product));
+                push_bigint_checked(&mut stack, product, max_num_len)?;
             }
             OP_2MUL => {
-                let a = pop_bigint(&mut stack)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let two = BigInt::from(2);
                 let product = a * two;
-                stack.push(encode_bigint(product));
+                push_bigint_checked(&mut stack, product, max_num_len)?;
             }
             OP_DIV => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if b == BigInt::zero() {
                     let msg = "OP_DIV failed, divide by 0".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
                 let quotient = a / b;
-                stack.push(encode_bigint(quotient));
+                push_bigint_checked(&mut stack, quotient, max_num_len)?;
             }
             OP_2DIV => {
-                let a = pop_bigint(&mut stack)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let b = BigInt::from(2);
 
                 let quotient = a / b;
-                stack.push(encode_bigint(quotient));
+                push_bigint_checked(&mut stack, quotient, max_num_len)?;
             }
             OP_MOD => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if b == BigInt::zero() {
                     let msg = "OP_MOD failed, divide by 0".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
                 let remainder = a % b;
-                stack.push(encode_bigint(remainder));
+                push_bigint_checked(&mut stack, remainder, max_num_len)?;
             }
             OP_BOOLAND => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != BigInt::zero() && b != BigInt::zero() {
                     stack.push(encode_num(1)?);
                 } else {
@@ -768,8 +784,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_BOOLOR => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != BigInt::zero() || b != BigInt::zero() {
                     stack.push(encode_num(1)?);
                 } else {
@@ -777,8 +793,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_NUMEQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a == b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -786,16 +802,16 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_NUMEQUALVERIFY => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != b {
                     let msg = "Numbers are not equal".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
             }
             OP_NUMNOTEQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -803,8 +819,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_LESSTHAN => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a < b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -812,8 +828,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_GREATERTHAN => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a > b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -821,8 +837,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_LESSTHANOREQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a <= b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -830,8 +846,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_GREATERTHANOREQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a >= b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -839,27 +855,27 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_MIN => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a < b {
-                    stack.push(encode_bigint(a));
+                    push_bigint_checked(&mut stack, a, max_num_len)?;
                 } else {
-                    stack.push(encode_bigint(b));
+                    push_bigint_checked(&mut stack, b, max_num_len)?;
                 }
             }
             OP_MAX => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a > b {
-                    stack.push(encode_bigint(a));
+                    push_bigint_checked(&mut stack, a, max_num_len)?;
                 } else {
-                    stack.push(encode_bigint(b));
+                    push_bigint_checked(&mut stack, b, max_num_len)?;
                 }
             }
             OP_WITHIN => {
-                let max = pop_bigint(&mut stack)?;
-                let min = pop_bigint(&mut stack)?;
-                let x = pop_bigint(&mut stack)?;
+                let max = pop_bigint_checked(&mut stack, max_num_len)?;
+                let min = pop_bigint_checked(&mut stack, max_num_len)?;
+                let x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x >= min && x < max {
                     stack.push(encode_num(1)?);
                 } else {
@@ -868,7 +884,7 @@ pub fn core_eval<T: Checker>(
             }
             OP_NUM2BIN => {
                 check_stack_size(2, &stack)?;
-                let m = pop_bigint(&mut stack)?;
+                let m = pop_bigint_checked(&mut stack, max_num_len)?;
                 let mut n = stack.pop().unwrap();
                 if m < BigInt::one() {
                     let msg = format!("OP_NUM2BIN failed. m too small: {m}");
@@ -879,10 +895,11 @@ pub fn core_eval<T: Checker>(
                     let msg = "OP_NUM2BIN failed. n longer than m".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
-                if m > BigInt::from(2147483647) {
+                if m > BigInt::from(max_num_len) {
                     let msg = "OP_NUM2BIN failed. m too big".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
+                check_script_num_length(nlen, max_num_len)?;
                 let mut v = Vec::with_capacity(m.to_usize().unwrap());
                 let mut neg = 0;
                 if nlen > 0 {
@@ -898,13 +915,16 @@ pub fn core_eval<T: Checker>(
                 }
                 // Add the sign
                 v[0] |= neg;
+                check_script_num_length(v.len(), max_num_len)?;
                 stack.push(v);
             }
             OP_BIN2NUM => {
                 check_stack_size(1, &stack)?;
                 let mut v = stack.pop().unwrap();
+                check_script_num_length(v.len(), max_num_len)?;
                 let n = decode_bigint(&mut v);
                 let e = encode_bigint(n);
+                check_script_num_length(e.len(), max_num_len)?;
                 stack.push(e);
             }
             OP_RIPEMD160 => {
@@ -1288,6 +1308,10 @@ fn skip_branch(script: &[u8], mut i: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::script::stack::{
+        MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,
+        MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
+    };
     use crate::script::Script;
     use hex;
     use std::cell::RefCell;
@@ -2285,5 +2309,52 @@ mod tests {
     #[test]
     fn is_push_only_rejects_functional_opcodes() {
         assert!(!is_push_only(&[OP_2, OP_3, OP_ADD]));
+    }
+
+    #[test]
+    fn max_script_num_length_by_context() {
+        let c1 = MockChecker::with_tx_version(1);
+        assert_eq!(
+            max_script_num_length(&c1, NO_FLAGS),
+            MAX_SCRIPT_NUM_LENGTH_GENESIS
+        );
+        let c2 = MockChecker::with_tx_version(2);
+        assert_eq!(
+            max_script_num_length(&c2, NO_FLAGS),
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        );
+        let c3 = MockChecker::new();
+        assert_eq!(
+            max_script_num_length(&c3, NO_FLAGS),
+            MAX_SCRIPT_NUM_LENGTH_GENESIS
+        );
+        assert_eq!(
+            max_script_num_length(&c3, PREGENESIS_RULES),
+            MAX_SCRIPT_NUM_LENGTH_PREGENESIS
+        );
+    }
+
+    #[test]
+    fn genesis_script_num_limit_rejects_oversized_bin2num() {
+        let mut script = Script::new();
+        script.append(OP_PUSHDATA4);
+        script.append_slice(&(750_001_u32).to_le_bytes());
+        script.0.extend(std::iter::repeat_n(0u8, 750_001));
+        script.append(OP_BIN2NUM);
+        script.append(OP_1);
+        let mut c = MockChecker::with_tx_version(1);
+        assert!(eval(&script.0, &mut c, NO_FLAGS).is_err());
+    }
+
+    #[test]
+    fn chronicle_script_num_limit_accepts_genesis_max_bin2num() {
+        let mut script = Script::new();
+        script.append(OP_PUSHDATA4);
+        script.append_slice(&(750_000_u32).to_le_bytes());
+        script.0.extend(std::iter::repeat_n(0u8, 750_000));
+        script.append(OP_BIN2NUM);
+        script.append(OP_1);
+        let mut c = MockChecker::with_tx_version(2);
+        assert!(eval(&script.0, &mut c, NO_FLAGS).is_ok());
     }
 }

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -520,6 +520,7 @@ impl fmt::Debug for Script {
 mod tests {
     use super::op_codes::*;
     use super::*;
+    use crate::script::stack::encode_num;
 
     #[test]
     fn append_data() {
@@ -555,6 +556,24 @@ mod tests {
         s.append_data(&vec![0; 65536]);
         assert!(s.0[0] == OP_PUSHDATA4 && s.0[1] == 0 && s.0[2] == 0 && s.0[3] == 1);
         assert!(s.0.len() == 65541);
+    }
+
+    #[test]
+    fn eval_with_stack_start_at_skips_prefix() {
+        use crate::script::op_codes::*;
+        let script = [OP_1, OP_2, OP_3];
+        let (stack, _, _) = Script(script.to_vec())
+            .eval_with_stack(
+                &mut TransactionlessChecker {},
+                NO_FLAGS,
+                Some(2),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack[0], encode_num(3).unwrap());
     }
 
     #[test]

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -30,8 +30,12 @@ pub mod stack;
 pub use self::checker::{Checker, TransactionChecker, TransactionlessChecker, ZChecker};
 pub(crate) use self::interpreter::next_op;
 pub use self::interpreter::{
-    eval_two_phase, is_push_only, uses_relaxed_malleability, uses_two_phase_eval, NO_FLAGS,
-    PREGENESIS_RULES,
+    eval_two_phase, is_push_only, max_script_num_length, uses_relaxed_malleability,
+    uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
+};
+pub use self::stack::{
+    check_script_num_length, MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,
+    MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
 };
 pub use self::stack::Stack;
 

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -256,7 +256,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
     let len = s.len();
 
     if len == 0 {
-        println!("Zero length number");
         return Ok(BigInt::zero());
     }
 
@@ -278,7 +277,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
         if s[len - 1] & 128 != 0 {
             val = -val;
         }
-        println!("Returing this way");
         return Ok(BigInt::from(val));
     }
 
@@ -289,7 +287,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
     }
     let mut big_int_bytes = s.to_vec();
     big_int_bytes[len - 1] &= !0x80; // Clear the sign bit
-    println!("Returned this big num way");
     Ok(BigInt::from_bytes_le(sign, &big_int_bytes))
 }
 

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -5,6 +5,26 @@ use num_traits::Zero;
 // Type to simplify the types..
 pub type Stack = Vec<Vec<u8>>;
 
+/// Maximum script number size before Genesis (4 bytes).
+pub const MAX_SCRIPT_NUM_LENGTH_PREGENESIS: usize = 4;
+
+/// Maximum script number size after Genesis (750 KB).
+pub const MAX_SCRIPT_NUM_LENGTH_GENESIS: usize = 750_000;
+
+/// Maximum script number size after Chronicle (32 MB).
+pub const MAX_SCRIPT_NUM_LENGTH_CHRONICLE: usize = 32 * 1024 * 1024;
+
+/// Returns an error when a script number exceeds the allowed byte length.
+#[inline]
+pub fn check_script_num_length(len: usize, max_len: usize) -> Result<(), ChainGangError> {
+    if len > max_len {
+        return Err(ChainGangError::ScriptError(format!(
+            "Script number exceeds maximum length of {max_len}"
+        )));
+    }
+    Ok(())
+}
+
 /// Converts a stack item to a bool
 #[inline]
 pub fn decode_bool(s: &[u8]) -> bool {
@@ -107,6 +127,31 @@ pub fn pop_bigint(stack: &mut Stack) -> Result<BigInt, ChainGangError> {
     }
     let mut top = stack.pop().unwrap();
     Ok(decode_bigint(&mut top))
+}
+
+/// Pops a bigint number, enforcing a maximum encoded byte length.
+#[inline]
+pub fn pop_bigint_checked(stack: &mut Stack, max_len: usize) -> Result<BigInt, ChainGangError> {
+    if stack.is_empty() {
+        let msg = "Cannot pop bigint, empty stack".to_string();
+        return Err(ChainGangError::ScriptError(msg));
+    }
+    let mut top = stack.pop().unwrap();
+    check_script_num_length(top.len(), max_len)?;
+    Ok(decode_bigint(&mut top))
+}
+
+/// Pushes a bigint number, enforcing a maximum encoded byte length.
+#[inline]
+pub fn push_bigint_checked(
+    stack: &mut Stack,
+    val: BigInt,
+    max_len: usize,
+) -> Result<(), ChainGangError> {
+    let encoded = encode_bigint(val);
+    check_script_num_length(encoded.len(), max_len)?;
+    stack.push(encoded);
+    Ok(())
 }
 
 /// Converts a stack item to a number
@@ -318,6 +363,28 @@ mod tests {
     fn pop_num_minimal_rejects_non_minimal_encoding() {
         assert!(pop_num_minimal(&mut vec![vec![0, 0, 0, 0]], true).is_err());
         assert!(pop_num_minimal(&mut vec![vec![1]], true).unwrap() == 1);
+    }
+
+    #[test]
+    fn check_script_num_length_enforces_limit() {
+        assert!(check_script_num_length(750_000, MAX_SCRIPT_NUM_LENGTH_GENESIS).is_ok());
+        assert!(check_script_num_length(750_001, MAX_SCRIPT_NUM_LENGTH_GENESIS).is_err());
+        assert!(check_script_num_length(
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE,
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        )
+        .is_ok());
+        assert!(check_script_num_length(
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE + 1,
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn push_bigint_checked_enforces_limit() {
+        let oversized = vec![1u8; MAX_SCRIPT_NUM_LENGTH_GENESIS + 1];
+        assert!(pop_bigint_checked(&mut vec![oversized], MAX_SCRIPT_NUM_LENGTH_GENESIS).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enforce maximum encoded script number sizes during evaluation: 4 bytes (pre-genesis), 750 KB (`version == 1`), 32 MB (`version > 1`).
- Apply limits to bigint stack ops, `OP_BIN2NUM`, and `OP_NUM2BIN`.
- Add Python `MAX_SCRIPT_NUM_LENGTH_CHRONICLE` constant for documentation parity.

## Test plan
- [x] `cargo test --lib` (159 tests, including 750 KB reject/accept boundary tests)
- [ ] Merge after #89 (`chronicle/malleability-relaxation`)


Made with [Cursor](https://cursor.com)