### PR TITLE
Fix Python script eval breakpoints and Chronicle doc gaps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ crate-type = ["cdylib", "lib"]
 opt-level = "s"     # Optimize for size over speed
 lto = true          # Enable link-time optimizations to shrink binary
 
-["features"]
+[features]
 default = ["dep:serde", "dep:serde_json"]
 interface = ["dep:serde", "dep:serde_json", "dep:reqwest", "dep:async-mutex", "dep:async-trait"]
 python = ["dep:serde", "dep:serde_json", "dep:pyo3"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This library provides a Python interface for building BitcoinSV scripts and tran
 
 For documentation of the Python Classes see below.
 
+## Chronicle upgrade
+
+Bitcoin SV [Chronicle](https://docs.bsvblockchain.org/network-topology/nodes/sv-node/chronicle-release) support is implemented in the Rust library (`chain-gang`). See [docs/Chronicle.md](docs/Chronicle.md) for sighash routing, opcodes, two-phase script evaluation, malleability rules, and script number limits.
+
+Chronicle behavior is gated on **`tx.version > 1`** when validating transactions in Rust (`Tx.validate`). Use `version: 2` (or higher) on spending transactions to opt in.
+
+**Python `Context` debugger:** stepping scripts via `Context` uses the legacy single-script evaluator without transaction version. It does not perform two-phase unlock/lock evaluation or version-gated malleability rules. For Chronicle-accurate validation, use Rust `Tx.validate` or build unlock/lock scripts explicitly. `OP_VER` and related opcodes require a transaction version and will fail in `Context` unless a version-aware checker is added.
+
 # Python Installation
 As this library is hosted on PyPi (https://pypi.org/project/tx-engine/) and is installed using:
 
@@ -105,6 +113,9 @@ Context has the following methods:
 * `__init__(self, script: Script, cmds: Commands = None, ip_limit: int , z: bytes)` - constructor
 * `evaluate_core(self, quiet: bool = False) -> bool` - evaluates the script/cmds using the the interpreter and returns the stacks (`tack`, `alt_stack`). if quiet is true, dont print exceptions
 * `evaluate(self, quiet: bool = False) -> bool` - executes the script and decode stack elements to numbers (`stack`, `alt_stack`). Checks `stack` is true on return. if quiet is true, dont print exceptions.
+
+Note: `evaluate` / `evaluate_core` use the legacy debugger path (see [Chronicle upgrade](#chronicle-upgrade)). They do not apply Chronicle two-phase eval or version-gated malleability rules.
+
 * `get_stack(self) -> Stack` - Return the `stack` as human readable
 * `get_altstack(self) -> Stack`-  Return the `alt_stack` as human readable
 * `set_ip_start(self, start: int)` - sets the start location for the intepreter. 

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -23,6 +23,7 @@ BSV only Features
 * Wallet key derivation and mnemonic parsing
 * Various Bitcoin primitives
 * Genesis upgrade support
+* [Chronicle upgrade](Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules)
 
 `Chain-gang` is based on `Rust-SV` An open source library to build Bitcoin SV applications and infrastructure in Rust. The documentation for `Rust-SV` can be found here: 
 [Rust-SV Documentation](https://docs.rs/sv/)

--- a/python/src/tests/test_debug.py
+++ b/python/src/tests/test_debug.py
@@ -34,6 +34,16 @@ class DebugTest(unittest.TestCase):
         self.assertTrue(context.evaluate())
         self.assertEqual(context.get_stack(), Stack([[1], [2], [3]]))
 
+    def test_ip_limit_with_z_matches_without_z(self):
+        """Regression: py_script_eval_pystack must pass start_at/break_at consistently when z is set."""
+        script = Script([OP_1, OP_2, OP_3, OP_4])
+        z = bytes(32)
+        without_z = Context(script=script, ip_limit=2)
+        with_z = Context(script=script, ip_limit=2, z=z)
+        self.assertTrue(without_z.evaluate_core())
+        self.assertTrue(with_z.evaluate_core())
+        self.assertEqual(without_z.get_stack(), with_z.get_stack())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tx_engine/engine/context.py
+++ b/python/src/tx_engine/engine/context.py
@@ -39,8 +39,10 @@ class Context:
         self.alt_stack = Stack()
 
     def evaluate_core(self, quiet: bool = False) -> bool:
-        """ evaluate_core calls the interpreter and returns the stacks
-            if quiet is true, dont print exceptions
+        """Evaluate script opcodes and update stack/alt_stack.
+
+        Uses the legacy single-phase evaluator without transaction version.
+        For Chronicle rules (two-phase eval, malleability), use Rust Tx.validate.
         """
 
         try:

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -154,8 +154,8 @@ fn py_script_eval_pystack(
             script.eval_with_stack(
                 &mut ZChecker { z },
                 NO_FLAGS,
-                break_at,
                 start_at,
+                break_at,
                 main_stack,
                 alternative_stack,
             )?

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -95,23 +95,11 @@ impl Checker for ZChecker {
 
         let sig_hash = self.z;
         let der_sig = &sig[0..sig.len() - 1];
-        let signature = match Signature::from_der(der_sig) {
-            Ok(sig) => sig,
-            Err(e) => {
-                println!("Failed to parse the signature: {e}");
-                return Err(e.into()); // Return the error to the caller
-            }
-        };
+        let signature = Signature::from_der(der_sig)?;
 
         let message = sig_hash.0;
 
-        let verifying_key = match VerifyingKey::from_sec1_bytes(pubkey) {
-            Ok(verkey) => verkey,
-            Err(e) => {
-                println!("Failed to parse the public key {e}");
-                return Err(e.into());
-            }
-        };
+        let verifying_key = VerifyingKey::from_sec1_bytes(pubkey)?;
 
         Ok(verifying_key.verify_prehash(&message, &signature).is_ok())
     }

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -520,6 +520,7 @@ impl fmt::Debug for Script {
 mod tests {
     use super::op_codes::*;
     use super::*;
+    use crate::script::stack::encode_num;
 
     #[test]
     fn append_data() {
@@ -555,6 +556,24 @@ mod tests {
         s.append_data(&vec![0; 65536]);
         assert!(s.0[0] == OP_PUSHDATA4 && s.0[1] == 0 && s.0[2] == 0 && s.0[3] == 1);
         assert!(s.0.len() == 65541);
+    }
+
+    #[test]
+    fn eval_with_stack_start_at_skips_prefix() {
+        use crate::script::op_codes::*;
+        let script = [OP_1, OP_2, OP_3];
+        let (stack, _, _) = Script(script.to_vec())
+            .eval_with_stack(
+                &mut TransactionlessChecker {},
+                NO_FLAGS,
+                Some(2),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack[0], encode_num(3).unwrap());
     }
 
     #[test]

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -256,7 +256,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
     let len = s.len();
 
     if len == 0 {
-        println!("Zero length number");
         return Ok(BigInt::zero());
     }
 
@@ -278,7 +277,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
         if s[len - 1] & 128 != 0 {
             val = -val;
         }
-        println!("Returing this way");
         return Ok(BigInt::from(val));
     }
 
@@ -289,7 +287,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
     }
     let mut big_int_bytes = s.to_vec();
     big_int_bytes[len - 1] &= !0x80; // Clear the sign bit
-    println!("Returned this big num way");
     Ok(BigInt::from_bytes_le(sign, &big_int_bytes))
 }
 


### PR DESCRIPTION
## Summary
- Fix swapped `start_at`/`break_at` in `py_script_eval_pystack` when a sighash `z` is provided (debugger breakpoints with precomputed digest).
- Remove stray `println!` from `decode_number_combined` and `ZChecker::check_sig`.
- Correct `Cargo.toml` `[features]` section header.
- Document Chronicle in README / Rust docs and note Python `Context` debugger limitations.

## Test plan
- [x] `cargo test --all-features` (168 tests)
- [x] `python3 -m unittest src.tests.test_debug` (includes `test_ip_limit_with_z_matches_without_z`)
- [ ] Can merge independently of Chronicle stack, or after #90


Made with [Cursor](https://cursor.com)