### PR TITLE
Python Chronicle parity for Context and script eval

### DIFF
--- a/python/src/tests/test_chronicle_context.py
+++ b/python/src/tests/test_chronicle_context.py
@@ -1,0 +1,38 @@
+""" Chronicle Python Context parity tests
+"""
+import unittest
+
+from tx_engine import Context, Script
+from tx_engine.engine.util import max_script_num_length, MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+
+
+class ChronicleContextTest(unittest.TestCase):
+    """ Chronicle rules exposed through Python Context and util helpers
+    """
+
+    def test_op_ver_with_tx_version(self):
+        script = Script.parse_string("OP_VER OP_2 OP_NUMEQUAL")
+        self.assertTrue(Context(script=script, tx_version=2).evaluate())
+        self.assertFalse(Context(script=script, tx_version=1).evaluate())
+
+    def test_two_phase_carries_stack(self):
+        unlock = Script.parse_string("OP_2 OP_3 OP_ADD")
+        lock = Script.parse_string("OP_5 OP_EQUAL")
+        self.assertTrue(
+            Context(script=unlock, lock_script=lock, tx_version=2).evaluate()
+        )
+
+    def test_relaxed_clean_stack(self):
+        script = Script.parse_string("OP_1 OP_2 OP_1")
+        self.assertFalse(Context(script=script, tx_version=1).evaluate())
+        self.assertTrue(Context(script=script, tx_version=2).evaluate())
+
+    def test_max_script_num_length(self):
+        self.assertEqual(max_script_num_length(1), 750_000)
+        self.assertEqual(max_script_num_length(2), MAX_SCRIPT_NUM_LENGTH_CHRONICLE)
+        self.assertEqual(max_script_num_length(None), 750_000)
+        self.assertEqual(max_script_num_length(2, pregenesis=True), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/tx_engine/engine/context.py
+++ b/python/src/tx_engine/engine/context.py
@@ -3,18 +3,34 @@
 
 from typing import Optional, List
 
-from tx_engine.tx_engine import py_script_eval_pystack, Script, Stack
+from tx_engine.tx_engine import (
+    py_script_eval_pystack,
+    py_script_eval_two_phase_pystack,
+    Script,
+    Stack,
+)
+from tx_engine.engine.util import decode_num
 
 
 class Context:
     """ This class captures an execution context for the script
     """
-    def __init__(self, script: None | Script = None, ip_start: None | int = None, ip_limit: None | int = None, z: None | bytes = None):
+    def __init__(
+        self,
+        script: None | Script = None,
+        ip_start: None | int = None,
+        ip_limit: None | int = None,
+        z: None | bytes = None,
+        tx_version: None | int = None,
+        lock_script: None | Script = None,
+    ):
         """ Intial setup
         """
         self.ip_start: Optional[int]
         self.ip_limit: Optional[int]
         self.z: Optional[bytes]
+        self.tx_version: Optional[int]
+        self.lock_cmds: Optional[List[int]]
         self.stack: Stack = Stack()
         self.alt_stack: Stack = Stack()
 
@@ -26,6 +42,8 @@ class Context:
         self.ip_start = ip_start if ip_start else None
         self.ip_limit = ip_limit if ip_limit else None
         self.z = z if z else None
+        self.tx_version = tx_version if tx_version is not None else None
+        self.lock_cmds = lock_script.get_commands() if lock_script else None
 
     def set_commands(self, script: Script) -> None:
         """ Set the commands
@@ -38,15 +56,48 @@ class Context:
         self.stack = Stack()
         self.alt_stack = Stack()
 
+    def _uses_two_phase(self) -> bool:
+        return (
+            self.lock_cmds is not None
+            and self.tx_version is not None
+            and self.tx_version > 1
+        )
+
+    def _stack_top_is_true(self) -> bool:
+        if self.stack.size() == 0:
+            return False
+        top = self.stack[self.stack.size() - 1]
+        if top == b"" or top == []:
+            return False
+        return decode_num(top) != 0
+
     def evaluate_core(self, quiet: bool = False) -> bool:
         """Evaluate script opcodes and update stack/alt_stack.
 
-        Uses the legacy single-phase evaluator without transaction version.
-        For Chronicle rules (two-phase eval, malleability), use Rust Tx.validate.
+        When ``tx_version > 1`` and ``lock_script`` is set, uses Chronicle two-phase
+        unlock/lock evaluation. Pass ``tx_version`` for Chronicle opcodes such as OP_VER.
         """
 
         try:
-            (self.stack, self.alt_stack, finish_loc) = py_script_eval_pystack(self.cmds, self.ip_start, self.ip_limit, self.z, self.stack, self.alt_stack)
+            if self._uses_two_phase():
+                (self.stack, self.alt_stack, finish_loc) = py_script_eval_two_phase_pystack(
+                    self.cmds,
+                    self.lock_cmds,
+                    self.tx_version,
+                    self.z,
+                    None,
+                    None,
+                )
+            else:
+                (self.stack, self.alt_stack, finish_loc) = py_script_eval_pystack(
+                    self.cmds,
+                    self.ip_start,
+                    self.ip_limit,
+                    self.z,
+                    self.stack,
+                    self.alt_stack,
+                    self.tx_version,
+                )
         except Exception as e:
             if not quiet:
                 print(f"script_eval exception '{e}'")
@@ -60,6 +111,17 @@ class Context:
         if not self.evaluate_core(quiet):
             return False
 
+        # Partial execution for debugging: skip final-stack policy.
+        if self.ip_limit is not None:
+            if self.stack.size() == 0:
+                return False
+            if self.get_stack()[0] == [0] or self.get_stack()[0] == []:
+                return False
+            return True
+
+        if self.tx_version is not None and self.tx_version > 1:
+            return self._stack_top_is_true()
+
         if self.stack.size() == 0:
             return False
 
@@ -68,6 +130,9 @@ class Context:
             # no entry or 0 => false.
             if self.get_stack() == Stack([[]]) or self.get_stack() == Stack([[0]]):
                 return False
+
+        if self.stack.size() != 1:
+            return False
 
         if self.get_stack()[0] == [0] or self.get_stack()[0] == []:
             return False

--- a/python/src/tx_engine/engine/context.py
+++ b/python/src/tx_engine/engine/context.py
@@ -57,11 +57,7 @@ class Context:
         self.alt_stack = Stack()
 
     def _uses_two_phase(self) -> bool:
-        return (
-            self.lock_cmds is not None
-            and self.tx_version is not None
-            and self.tx_version > 1
-        )
+        return self.lock_cmds is not None and self.tx_version is not None and self.tx_version > 1
 
     def _stack_top_is_true(self) -> bool:
         if self.stack.size() == 0:
@@ -122,6 +118,9 @@ class Context:
         if self.tx_version is not None and self.tx_version > 1:
             return self._stack_top_is_true()
 
+        if self.tx_version == 1 and self.stack.size() != 1:
+            return False
+
         if self.stack.size() == 0:
             return False
 
@@ -130,9 +129,6 @@ class Context:
             # no entry or 0 => false.
             if self.get_stack() == Stack([[]]) or self.get_stack() == Stack([[0]]):
                 return False
-
-        if self.stack.size() != 1:
-            return False
 
         if self.get_stack()[0] == [0] or self.get_stack()[0] == []:
             return False

--- a/python/src/tx_engine/engine/util.py
+++ b/python/src/tx_engine/engine/util.py
@@ -14,7 +14,6 @@ MAX_SCRIPT_NUM_LENGTH_CHRONICLE: Final = 32 * 1024 * 1024
 MAXIMUM_ELEMENT_SIZE: Final = MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS
 
 # Curve constants
-# perhaps we can source these from the secp256k1 library rather than here?
 PRIME_INT: Final = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
 GROUP_ORDER_INT: Final = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 HALF_GROUP_ORDER_INT: Final = GROUP_ORDER_INT // 2
@@ -22,6 +21,15 @@ Gx: Final = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798
 Gx_bytes: Final = bytes.fromhex('79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798')
 Gy: Final = 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8
 GUncompressed: Final = "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+
+
+def max_script_num_length(tx_version: int | None = None, pregenesis: bool = False) -> int:
+    """Return the maximum encoded script-number length for the given context."""
+    if pregenesis:
+        return MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS
+    if tx_version is not None and tx_version > 1:
+        return MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+    return MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS
 
 
 def encode_num(num: int) -> bytes:
@@ -63,13 +71,15 @@ def is_minimally_encoded(element, max_element_size=MAXIMUM_ELEMENT_SIZE) -> bool
     return True
 
 
-def decode_num(element: StackElement, check_encoding=False) -> int:
+def decode_num(element: StackElement, check_encoding=False, tx_version: int | None = None) -> int:
     """ Take a byte(array), return a number
     """
     if element == b"":
         return 0
 
-    if check_encoding and not is_minimally_encoded(element):
+    if check_encoding and not is_minimally_encoded(
+        element, max_script_num_length(tx_version)
+    ):
         if isinstance(element, bytes):
             raise ValueError(f"Value is not minimally encoded: {element.hex()}")
         raise ValueError(f"Value is not minimally encoded: {element}")

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -19,7 +19,10 @@ use crate::{
             PyWallet,
         },
     },
-    script::{stack::Stack, Script, TransactionlessChecker, ZChecker, NO_FLAGS},
+    script::{
+        eval_two_phase_with_stack, stack::Stack, Script, TransactionlessChecker, TxVersionChecker,
+        ZChecker, ZVersionChecker, NO_FLAGS,
+    },
     transaction::sighash::{sig_hash_preimage, sig_hash_preimage_checksig_index, SigHashCache},
     util::{hash160, sha256d, ChainGangError, Hash256},
     wallet::{
@@ -29,6 +32,88 @@ use crate::{
 };
 
 pub type Bytes = Vec<u8>;
+
+fn parse_z_bytes(sig_hash: &[u8]) -> PyResult<Hash256> {
+    let z_array: [u8; 32] = sig_hash.try_into().map_err(|_| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>("z_bytes must be exactly 32 bytes long")
+    })?;
+    Ok(Hash256(z_array))
+}
+
+fn eval_script_with_stack(
+    script: &Script,
+    z: Option<Hash256>,
+    tx_version: Option<i32>,
+    start_at: Option<usize>,
+    break_at: Option<usize>,
+    main_stack: Option<Stack>,
+    alternative_stack: Option<Stack>,
+) -> Result<(Stack, Stack, Option<usize>), ChainGangError> {
+    match (z, tx_version) {
+        (Some(z), Some(tx_version)) => {
+            let mut checker = ZVersionChecker { z, tx_version };
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+        (Some(z), None) => {
+            let mut checker = ZChecker { z };
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+        (None, Some(tx_version)) => {
+            let mut checker = TxVersionChecker { tx_version };
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+        (None, None) => {
+            let mut checker = TransactionlessChecker {};
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+    }
+}
+
+fn eval_two_phase_with_checker(
+    unlock: &[u8],
+    lock: &[u8],
+    z: Option<Hash256>,
+    tx_version: i32,
+) -> Result<(Stack, Stack), ChainGangError> {
+    match z {
+        Some(z) => {
+            let mut checker = ZVersionChecker { z, tx_version };
+            eval_two_phase_with_stack(unlock, lock, &mut checker, NO_FLAGS)
+        }
+        None => {
+            let mut checker = TxVersionChecker { tx_version };
+            eval_two_phase_with_stack(unlock, lock, &mut checker, NO_FLAGS)
+        }
+    }
+}
 
 #[pyfunction(name = "p2pkh_script")]
 fn py_p2pkh_pyscript(h160: &[u8]) -> PyScript {
@@ -72,55 +157,35 @@ pub fn py_public_key_to_address(public_key: &[u8], network: &str) -> PyResult<St
 ///  * py_script - the script to execute
 ///  * break_at - the instruction to stop at, or None
 ///  * z - the sig_hash of the transaction as bytes, or None
+///  * tx_version - optional transaction version for Chronicle opcodes
 #[pyfunction]
-#[pyo3(signature = (py_script, break_at=None, z=None))]
+#[pyo3(signature = (py_script, break_at=None, z=None, tx_version=None))]
 fn py_script_eval(
     py_script: &[u8],
     break_at: Option<usize>,
     z: Option<&[u8]>,
+    tx_version: Option<i32>,
 ) -> PyResult<(Stack, Stack, Option<usize>)> {
     let mut script = Script::new();
     script.append_slice(py_script);
-    // Pick the appropriate transaction checker
-    match z {
-        Some(sig_hash) => {
-            // Ensure the slice is exactly 32 bytes long
-            let z_bytes = sig_hash;
-            let z_array: [u8; 32] = match z_bytes.try_into() {
-                Ok(array) => array,
-                Err(_) => {
-                    // Handle the error if `z_bytes` is not 32 bytes long
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                        "z_bytes must be exactly 32 bytes long",
-                    ));
-                }
-            };
-
-            let z = Hash256(z_array);
-            Ok(
-                script.eval_with_stack(
-                    &mut ZChecker { z },
-                    NO_FLAGS,
-                    None,
-                    break_at,
-                    None,
-                    None,
-                )?,
-            )
-        }
-        None => Ok(script.eval_with_stack(
-            &mut TransactionlessChecker {},
-            NO_FLAGS,
-            None,
-            break_at,
-            None,
-            None,
-        )?),
-    }
+    let z_hash = match z {
+        Some(sig_hash) => Some(parse_z_bytes(sig_hash)?),
+        None => None,
+    };
+    eval_script_with_stack(
+        &script,
+        z_hash,
+        tx_version,
+        None,
+        break_at,
+        None,
+        None,
+    )
+    .map_err(Into::into)
 }
 
 #[pyfunction]
-#[pyo3(signature = (py_script, start_at=None, break_at=None, z=None, stack_param=None, alt_stack_param=None))]
+#[pyo3(signature = (py_script, start_at=None, break_at=None, z=None, stack_param=None, alt_stack_param=None, tx_version=None))]
 fn py_script_eval_pystack(
     py_script: &[u8],
     start_at: Option<usize>,
@@ -128,47 +193,25 @@ fn py_script_eval_pystack(
     z: Option<&[u8]>,
     stack_param: Option<PyStack>,
     alt_stack_param: Option<PyStack>,
+    tx_version: Option<i32>,
 ) -> PyResult<(PyStack, PyStack, Option<usize>)> {
     let mut script = Script::new();
     script.append_slice(py_script);
-    // Handle stack and alt_stack parameters with match
     let main_stack = stack_param.map(|py_stack_main| py_stack_main.to_stack());
-
     let alternative_stack = alt_stack_param.map(|alt_stack_param| alt_stack_param.to_stack());
-
-    // Pick the appropriate transaction checker
-    let (main_stack, alt_stack, prog_counter) = match z {
-        Some(sig_hash) => {
-            // Ensure the slice is exactly 32 bytes long
-            let z_bytes = sig_hash;
-            let z_array: [u8; 32] = match z_bytes.try_into() {
-                Ok(array) => array,
-                Err(_) => {
-                    // Handle the error if `z_bytes` is not 32 bytes long
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                        "z_bytes must be exactly 32 bytes long",
-                    ));
-                }
-            };
-            let z = Hash256(z_array);
-            script.eval_with_stack(
-                &mut ZChecker { z },
-                NO_FLAGS,
-                start_at,
-                break_at,
-                main_stack,
-                alternative_stack,
-            )?
-        }
-        None => script.eval_with_stack(
-            &mut TransactionlessChecker {},
-            NO_FLAGS,
-            start_at,
-            break_at,
-            main_stack,
-            alternative_stack,
-        )?,
+    let z_hash = match z {
+        Some(sig_hash) => Some(parse_z_bytes(sig_hash)?),
+        None => None,
     };
+    let (main_stack, alt_stack, prog_counter) = eval_script_with_stack(
+        &script,
+        z_hash,
+        tx_version,
+        start_at,
+        break_at,
+        main_stack,
+        alternative_stack,
+    )?;
 
     let optional_i = match break_at {
         Some(_) => prog_counter,
@@ -179,6 +222,42 @@ fn py_script_eval_pystack(
         PyStack::from_stack(main_stack),
         PyStack::from_stack(alt_stack),
         optional_i,
+    ))
+}
+
+/// Evaluates unlock and lock scripts in separate phases (Chronicle, `tx.version > 1`).
+#[pyfunction]
+#[pyo3(signature = (unlock, lock, tx_version, z=None, stack_param=None, alt_stack_param=None))]
+fn py_script_eval_two_phase_pystack(
+    unlock: &[u8],
+    lock: &[u8],
+    tx_version: i32,
+    z: Option<&[u8]>,
+    stack_param: Option<PyStack>,
+    alt_stack_param: Option<PyStack>,
+) -> PyResult<(PyStack, PyStack, Option<usize>)> {
+    if tx_version <= 1 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "two-phase eval requires tx_version > 1",
+        ));
+    }
+    let main_stack = stack_param.map(|py_stack_main| py_stack_main.to_stack());
+    let alternative_stack = alt_stack_param.map(|alt_stack_param| alt_stack_param.to_stack());
+    if main_stack.is_some() || alternative_stack.is_some() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "two-phase eval does not accept initial stacks",
+        ));
+    }
+    let z_hash = match z {
+        Some(sig_hash) => Some(parse_z_bytes(sig_hash)?),
+        None => None,
+    };
+    let (main_stack, alt_stack) =
+        eval_two_phase_with_checker(unlock, lock, z_hash, tx_version)?;
+    Ok((
+        PyStack::from_stack(main_stack),
+        PyStack::from_stack(alt_stack),
+        None,
     ))
 }
 
@@ -383,6 +462,7 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_generate_wif_from_pw_nonce, m)?)?;
     m.add_function(wrap_pyfunction!(decode_num_stack, m)?)?;
     m.add_function(wrap_pyfunction!(py_script_eval_pystack, m)?)?;
+    m.add_function(wrap_pyfunction!(py_script_eval_two_phase_pystack, m)?)?;
     // Script
     m.add_class::<PyScript>()?;
 

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -117,6 +117,93 @@ impl Checker for ZChecker {
     }
 }
 
+/// Script checker that supplies `tx.version` for Chronicle opcodes without transaction validation.
+pub struct TxVersionChecker {
+    pub tx_version: i32,
+}
+
+impl Checker for TxVersionChecker {
+    fn check_sig(
+        &mut self,
+        _sig: &[u8],
+        _pubkey: &[u8],
+        _script: &[u8],
+    ) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn check_locktime(&self, _locktime: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn check_sequence(&self, _sequence: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn tx_version(&self) -> Result<i32, ChainGangError> {
+        Ok(self.tx_version)
+    }
+}
+
+/// Script checker that uses a provided sighash and transaction version (Chronicle debugging).
+pub struct ZVersionChecker {
+    pub z: Hash256,
+    pub tx_version: i32,
+}
+
+impl Checker for ZVersionChecker {
+    fn check_sig(
+        &mut self,
+        sig: &[u8],
+        pubkey: &[u8],
+        _script: &[u8],
+    ) -> Result<bool, ChainGangError> {
+        if sig.is_empty() {
+            return Err(ChainGangError::ScriptError(
+                "Signature too short".to_string(),
+            ));
+        }
+        let sighash_type = sig[sig.len() - 1];
+        if sighash_type & SIGHASH_FORKID == 0 {
+            return Err(ChainGangError::ScriptError(
+                "SIGHASH_FORKID not present".to_string(),
+            ));
+        }
+
+        let sig_hash = self.z;
+        let der_sig = &sig[0..sig.len() - 1];
+        let signature = Signature::from_der(der_sig)?;
+
+        let message = sig_hash.0;
+
+        let verifying_key = VerifyingKey::from_sec1_bytes(pubkey)?;
+
+        Ok(verifying_key.verify_prehash(&message, &signature).is_ok())
+    }
+
+    fn check_locktime(&self, _locktime: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn check_sequence(&self, _sequence: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn tx_version(&self) -> Result<i32, ChainGangError> {
+        Ok(self.tx_version)
+    }
+}
+
 /// Checks that external values in a script are correct for a specific transaction spend
 pub struct TransactionChecker<'a> {
     /// Spending transaction

--- a/src/script/format.rs
+++ b/src/script/format.rs
@@ -1,0 +1,311 @@
+use crate::script::op_codes::*;
+use crate::script::interpreter::next_op;
+use hex;
+
+/// How to render push-data and unknown opcodes when formatting a script.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ScriptFormatStyle {
+    /// Human-readable form used by `Script::string_representation`.
+    StringRep { include_byte_offsets: bool },
+    /// Compact form used by `Debug for Script`.
+    Debug,
+}
+
+/// Returns the canonical opcode name, if `byte` is a known opcode (not a direct push).
+pub fn opcode_name(byte: u8) -> Option<&'static str> {
+    match byte {
+        OP_0 => Some("OP_0"),
+        OP_1NEGATE => Some("OP_1NEGATE"),
+        OP_1 => Some("OP_1"),
+        OP_2 => Some("OP_2"),
+        OP_3 => Some("OP_3"),
+        OP_4 => Some("OP_4"),
+        OP_5 => Some("OP_5"),
+        OP_6 => Some("OP_6"),
+        OP_7 => Some("OP_7"),
+        OP_8 => Some("OP_8"),
+        OP_9 => Some("OP_9"),
+        OP_10 => Some("OP_10"),
+        OP_11 => Some("OP_11"),
+        OP_12 => Some("OP_12"),
+        OP_13 => Some("OP_13"),
+        OP_14 => Some("OP_14"),
+        OP_15 => Some("OP_15"),
+        OP_16 => Some("OP_16"),
+        OP_NOP => Some("OP_NOP"),
+        OP_VER => Some("OP_VER"),
+        OP_IF => Some("OP_IF"),
+        OP_NOTIF => Some("OP_NOTIF"),
+        OP_VERIF => Some("OP_VERIF"),
+        OP_VERNOTIF => Some("OP_VERNOTIF"),
+        OP_ELSE => Some("OP_ELSE"),
+        OP_ENDIF => Some("OP_ENDIF"),
+        OP_VERIFY => Some("OP_VERIFY"),
+        OP_RETURN => Some("OP_RETURN"),
+        OP_TOALTSTACK => Some("OP_TOALTSTACK"),
+        OP_FROMALTSTACK => Some("OP_FROMALTSTACK"),
+        OP_IFDUP => Some("OP_IFDUP"),
+        OP_DEPTH => Some("OP_DEPTH"),
+        OP_DROP => Some("OP_DROP"),
+        OP_DUP => Some("OP_DUP"),
+        OP_NIP => Some("OP_NIP"),
+        OP_OVER => Some("OP_OVER"),
+        OP_PICK => Some("OP_PICK"),
+        OP_ROLL => Some("OP_ROLL"),
+        OP_ROT => Some("OP_ROT"),
+        OP_SWAP => Some("OP_SWAP"),
+        OP_TUCK => Some("OP_TUCK"),
+        OP_2DROP => Some("OP_2DROP"),
+        OP_2DUP => Some("OP_2DUP"),
+        OP_3DUP => Some("OP_3DUP"),
+        OP_2OVER => Some("OP_2OVER"),
+        OP_2ROT => Some("OP_2ROT"),
+        OP_2SWAP => Some("OP_2SWAP"),
+        OP_CAT => Some("OP_CAT"),
+        OP_SPLIT => Some("OP_SPLIT"),
+        OP_SUBSTR => Some("OP_SUBSTR"),
+        OP_LEFT => Some("OP_LEFT"),
+        OP_RIGHT => Some("OP_RIGHT"),
+        OP_SIZE => Some("OP_SIZE"),
+        OP_AND => Some("OP_AND"),
+        OP_OR => Some("OP_OR"),
+        OP_XOR => Some("OP_XOR"),
+        OP_EQUAL => Some("OP_EQUAL"),
+        OP_EQUALVERIFY => Some("OP_EQUALVERIFY"),
+        OP_1ADD => Some("OP_1ADD"),
+        OP_1SUB => Some("OP_1SUB"),
+        OP_NEGATE => Some("OP_NEGATE"),
+        OP_ABS => Some("OP_ABS"),
+        OP_NOT => Some("OP_NOT"),
+        OP_0NOTEQUAL => Some("OP_0NOTEQUAL"),
+        OP_ADD => Some("OP_ADD"),
+        OP_SUB => Some("OP_SUB"),
+        OP_MUL => Some("OP_MUL"),
+        OP_2MUL => Some("OP_2MUL"),
+        OP_DIV => Some("OP_DIV"),
+        OP_2DIV => Some("OP_2DIV"),
+        OP_MOD => Some("OP_MOD"),
+        OP_LSHIFT => Some("OP_LSHIFT"),
+        OP_RSHIFT => Some("OP_RSHIFT"),
+        OP_LSHIFTNUM => Some("OP_LSHIFTNUM"),
+        OP_RSHIFTNUM => Some("OP_RSHIFTNUM"),
+        OP_BOOLAND => Some("OP_BOOLAND"),
+        OP_BOOLOR => Some("OP_BOOLOR"),
+        OP_NUMEQUAL => Some("OP_NUMEQUAL"),
+        OP_NUMEQUALVERIFY => Some("OP_NUMEQUALVERIFY"),
+        OP_NUMNOTEQUAL => Some("OP_NUMNOTEQUAL"),
+        OP_LESSTHAN => Some("OP_LESSTHAN"),
+        OP_GREATERTHAN => Some("OP_GREATERTHAN"),
+        OP_LESSTHANOREQUAL => Some("OP_LESSTHANOREQUAL"),
+        OP_GREATERTHANOREQUAL => Some("OP_GREATERTHANOREQUAL"),
+        OP_MIN => Some("OP_MIN"),
+        OP_MAX => Some("OP_MAX"),
+        OP_WITHIN => Some("OP_WITHIN"),
+        OP_NUM2BIN => Some("OP_NUM2BIN"),
+        OP_BIN2NUM => Some("OP_BIN2NUM"),
+        OP_RIPEMD160 => Some("OP_RIPEMD160"),
+        OP_SHA1 => Some("OP_SHA1"),
+        OP_SHA256 => Some("OP_SHA256"),
+        OP_HASH160 => Some("OP_HASH160"),
+        OP_HASH256 => Some("OP_HASH256"),
+        OP_CODESEPARATOR => Some("OP_CODESEPARATOR"),
+        OP_CHECKSIG => Some("OP_CHECKSIG"),
+        OP_CHECKSIGVERIFY => Some("OP_CHECKSIGVERIFY"),
+        OP_CHECKMULTISIG => Some("OP_CHECKMULTISIG"),
+        OP_CHECKMULTISIGVERIFY => Some("OP_CHECKMULTISIGVERIFY"),
+        OP_CHECKLOCKTIMEVERIFY => Some("OP_CHECKLOCKTIMEVERIFY"),
+        OP_CHECKSEQUENCEVERIFY => Some("OP_CHECKSEQUENCEVERIFY"),
+        _ => None,
+    }
+}
+
+fn append_direct_push(
+    out: &mut String,
+    script: &[u8],
+    i: usize,
+    len: u8,
+    style: ScriptFormatStyle,
+) -> bool {
+    let data_end = i + 1 + len as usize;
+    if data_end > script.len() {
+        return false;
+    }
+
+    match style {
+        ScriptFormatStyle::StringRep {
+            include_byte_offsets,
+        } => {
+            out.push_str("0x");
+            if include_byte_offsets {
+                out.push_str(&hex::encode(&script[i..data_end]));
+            } else {
+                out.push_str(&hex::encode(&script[i + 1..data_end]));
+            }
+        }
+        ScriptFormatStyle::Debug => {
+            out.push_str(&format!("OP_PUSH+{len} "));
+            out.push_str(&hex::encode(&script[i + 1..data_end]));
+        }
+    }
+    true
+}
+
+fn append_pushdata1(out: &mut String, script: &[u8], i: usize, style: ScriptFormatStyle) -> bool {
+    out.push_str("OP_PUSHDATA1 ");
+    if i + 2 > script.len() {
+        return false;
+    }
+    let len = script[i + 1] as usize;
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str(&format!("{len:#04x} ")),
+        ScriptFormatStyle::Debug => out.push_str(&format!("{len} ")),
+    }
+    if i + 2 + len > script.len() {
+        return false;
+    }
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str("0x"),
+        ScriptFormatStyle::Debug => {}
+    }
+    out.push_str(&hex::encode(&script[i + 2..i + 2 + len]));
+    true
+}
+
+fn append_pushdata2(out: &mut String, script: &[u8], i: usize, style: ScriptFormatStyle) -> bool {
+    out.push_str("OP_PUSHDATA2 ");
+    if i + 3 > script.len() {
+        return false;
+    }
+    let len = (script[i + 1] as usize) + ((script[i + 2] as usize) << 8);
+    match style {
+        ScriptFormatStyle::StringRep { .. } => {
+            out.push_str(&format!(
+                "{:#04x}{:02x} ",
+                script[i + 1] as usize,
+                script[i + 2] as usize
+            ));
+        }
+        ScriptFormatStyle::Debug => out.push_str(&format!("{len} ")),
+    }
+    if i + 3 + len > script.len() {
+        return false;
+    }
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str("0x"),
+        ScriptFormatStyle::Debug => {}
+    }
+    out.push_str(&hex::encode(&script[i + 3..i + 3 + len]));
+    true
+}
+
+fn append_pushdata4(out: &mut String, script: &[u8], i: usize, style: ScriptFormatStyle) -> bool {
+    out.push_str("OP_PUSHDATA4 ");
+    if i + 5 > script.len() {
+        return false;
+    }
+    let len = (script[i + 1] as usize)
+        + ((script[i + 2] as usize) << 8)
+        + ((script[i + 3] as usize) << 16)
+        + ((script[i + 4] as usize) << 24);
+    match style {
+        ScriptFormatStyle::StringRep { .. } => {
+            out.push_str(&format!(
+                "{:#04x}{:02x}{:02x}{:02x} ",
+                script[i + 1] as usize,
+                script[i + 2] as usize,
+                script[i + 3] as usize,
+                script[i + 4] as usize
+            ));
+        }
+        ScriptFormatStyle::Debug => out.push_str(&format!("{len} ")),
+    }
+    if i + 5 + len > script.len() {
+        return false;
+    }
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str("0x"),
+        ScriptFormatStyle::Debug => {}
+    }
+    out.push_str(&hex::encode(&script[i + 5..i + 5 + len]));
+    true
+}
+
+fn append_script_op(
+    out: &mut String,
+    script: &[u8],
+    i: usize,
+    style: ScriptFormatStyle,
+) -> bool {
+    match script[i] {
+        len @ 1..=75 => append_direct_push(out, script, i, len, style),
+        OP_PUSHDATA1 => append_pushdata1(out, script, i, style),
+        OP_PUSHDATA2 => append_pushdata2(out, script, i, style),
+        OP_PUSHDATA4 => append_pushdata4(out, script, i, style),
+        byte => {
+            if let Some(name) = opcode_name(byte) {
+                out.push_str(name);
+            } else {
+                out.push_str(&byte.to_string());
+            }
+            true
+        }
+    }
+}
+
+pub(crate) fn format_script(script: &[u8], style: ScriptFormatStyle, prefix: &str, suffix: &str) -> String {
+    let mut ret = String::new();
+    ret.push_str(prefix);
+    let mut i = 0;
+
+    while i < script.len() {
+        if i != 0 {
+            ret.push(' ');
+        }
+        if !append_script_op(&mut ret, script, i, style) {
+            break;
+        }
+        i = next_op(i, script);
+    }
+
+    if i < script.len() {
+        for item in script.iter().skip(i) {
+            ret.push_str(&format!(" {item}"));
+        }
+    }
+
+    ret.push_str(suffix);
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::script::Script;
+
+    #[test]
+    fn opcode_name_covers_chronicle_opcodes() {
+        assert_eq!(opcode_name(OP_VER), Some("OP_VER"));
+        assert_eq!(opcode_name(OP_SUBSTR), Some("OP_SUBSTR"));
+        assert_eq!(opcode_name(OP_LSHIFTNUM), Some("OP_LSHIFTNUM"));
+    }
+
+    #[test]
+    fn format_script_matches_string_representation() {
+        let mut script = Script::new();
+        script.append_slice(&[OP_10, OP_5, OP_DIV]);
+        assert_eq!(
+            script.string_representation(false),
+            format_script(&script.0, ScriptFormatStyle::StringRep { include_byte_offsets: false }, "", "")
+        );
+    }
+
+    #[test]
+    fn format_script_matches_debug() {
+        let mut script = Script::new();
+        script.append_slice(&[OP_10, OP_5, OP_DIV]);
+        assert_eq!(
+            format!("{script:?}"),
+            format_script(&script.0, ScriptFormatStyle::Debug, "[", "]")
+        );
+    }
+}

--- a/src/script/interpreter.rs
+++ b/src/script/interpreter.rs
@@ -1120,6 +1120,47 @@ pub fn eval_two_phase<T: Checker>(
     validate_final_stack(&stack, checker)
 }
 
+/// Like [`eval_two_phase`], but returns the final main and alt stacks after validation.
+pub fn eval_two_phase_with_stack<T: Checker>(
+    unlock: &[u8],
+    lock: &[u8],
+    checker: &mut T,
+    flags: u32,
+) -> Result<(Stack, Stack), ChainGangError> {
+    let ctx_unlock = TwoPhaseEvalContext {
+        lock_script: lock,
+        phase: TwoPhasePhase::Unlock,
+    };
+    let (stack, _, _) = core_eval(
+        unlock,
+        checker,
+        flags,
+        None,
+        None,
+        None,
+        None,
+        Some(&ctx_unlock),
+    )?;
+
+    let ctx_lock = TwoPhaseEvalContext {
+        lock_script: lock,
+        phase: TwoPhasePhase::Lock,
+    };
+    let (stack, alt_stack, _) = core_eval(
+        lock,
+        checker,
+        flags,
+        None,
+        None,
+        Some(stack),
+        None,
+        Some(&ctx_lock),
+    )?;
+
+    validate_final_stack(&stack, checker)?;
+    Ok((stack, alt_stack))
+}
+
 #[inline]
 fn check_multisig<T: Checker>(
     stack: &mut Stack,
@@ -2135,6 +2176,9 @@ mod tests {
         let lock = [OP_5, OP_EQUAL];
         let mut c = MockChecker::new();
         assert!(eval_two_phase(&unlock, &lock, &mut c, NO_FLAGS).is_ok());
+        let mut c2 = MockChecker::new();
+        let (stack, _) = eval_two_phase_with_stack(&unlock, &lock, &mut c2, NO_FLAGS).unwrap();
+        assert_eq!(stack.len(), 1);
     }
 
     #[test]

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -27,11 +27,14 @@ mod interpreter;
 pub mod op_codes;
 pub mod stack;
 
-pub use self::checker::{Checker, TransactionChecker, TransactionlessChecker, ZChecker};
+pub use self::checker::{
+    Checker, TransactionChecker, TransactionlessChecker, TxVersionChecker, ZChecker,
+    ZVersionChecker,
+};
 pub(crate) use self::interpreter::next_op;
 pub use self::interpreter::{
-    eval_two_phase, is_push_only, max_script_num_length, uses_relaxed_malleability,
-    uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
+    eval_two_phase, eval_two_phase_with_stack, is_push_only, max_script_num_length,
+    uses_relaxed_malleability, uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
 };
 pub use self::stack::{
     check_script_num_length, MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -16,12 +16,11 @@
 //! script.eval(&mut TransactionlessChecker {}, NO_FLAGS).unwrap();
 //! ```
 
-use crate::script::op_codes::*;
 use crate::util::ChainGangError;
-use hex;
 use std::fmt;
 
 mod checker;
+mod format;
 mod interpreter;
 #[allow(dead_code)]
 pub mod op_codes;
@@ -41,6 +40,8 @@ pub use self::stack::{
     MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
 };
 pub use self::stack::Stack;
+
+use self::format::{format_script, ScriptFormatStyle};
 
 /// Transaction script
 #[derive(Default, Clone, PartialEq, Eq, Hash)]
@@ -130,392 +131,25 @@ impl Script {
 
     // Used by PyScript
     pub fn string_representation(&self, include_byte_offsets: bool) -> String {
-        let script = &self.0;
-        let mut ret = String::new();
-        let mut i = 0;
-
-        while i < script.len() {
-            if i != 0 {
-                ret.push(' ')
-            }
-            match script[i] {
-                OP_0 => ret.push_str("OP_0"),
-                OP_1NEGATE => ret.push_str("OP_1NEGATE"),
-                OP_1 => ret.push_str("OP_1"),
-                OP_2 => ret.push_str("OP_2"),
-                OP_3 => ret.push_str("OP_3"),
-                OP_4 => ret.push_str("OP_4"),
-                OP_5 => ret.push_str("OP_5"),
-                OP_6 => ret.push_str("OP_6"),
-                OP_7 => ret.push_str("OP_7"),
-                OP_8 => ret.push_str("OP_8"),
-                OP_9 => ret.push_str("OP_9"),
-                OP_10 => ret.push_str("OP_10"),
-                OP_11 => ret.push_str("OP_11"),
-                OP_12 => ret.push_str("OP_12"),
-                OP_13 => ret.push_str("OP_13"),
-                OP_14 => ret.push_str("OP_14"),
-                OP_15 => ret.push_str("OP_15"),
-                OP_16 => ret.push_str("OP_16"),
-                len @ 1..=75 => {
-                    if i + 1 + len as usize <= script.len() {
-                        ret.push_str("0x");
-
-                        if include_byte_offsets {
-                            // include the byte length of the data
-                            ret.push_str(&hex::encode(&script[i..i + 1 + len as usize]));
-                        } else {
-                            // exclude the byte length of the data
-                            ret.push_str(&hex::encode(&script[i + 1..i + 1 + len as usize]));
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA1 => {
-                    ret.push_str("OP_PUSHDATA1 ");
-                    if i + 2 <= script.len() {
-                        let len = script[i + 1] as usize;
-                        ret.push_str(&format!("{len:#04x} "));
-                        if i + 2 + len <= script.len() {
-                            ret.push_str("0x");
-                            ret.push_str(&hex::encode(&script[i + 2..i + 2 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA2 => {
-                    ret.push_str("OP_PUSHDATA2 ");
-                    if i + 3 <= script.len() {
-                        let len = (script[i + 1] as usize) + ((script[i + 2] as usize) << 8);
-                        //ret.push_str(&format!("{:#04x} ", (script[i + 1] as usize)));
-                        //ret.push_str(&format!("{:#04x} ", (script[i + 2] as usize)));
-
-                        ret.push_str(&format!(
-                            "{:#04x}{:02x} ",
-                            (script[i + 1] as usize),
-                            (script[i + 2] as usize)
-                        ));
-
-                        if i + 3 + len <= script.len() {
-                            ret.push_str("0x");
-                            ret.push_str(&hex::encode(&script[i + 3..i + 3 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA4 => {
-                    ret.push_str("OP_PUSHDATA4 ");
-                    if i + 5 <= script.len() {
-                        let len = (script[i + 1] as usize)
-                            + ((script[i + 2] as usize) << 8)
-                            + ((script[i + 3] as usize) << 16)
-                            + ((script[i + 4] as usize) << 24);
-
-                        ret.push_str(&format!(
-                            "{:#04x}{:02x}{:02x}{:02x} ",
-                            (script[i + 1] as usize),
-                            (script[i + 2] as usize),
-                            (script[i + 3] as usize),
-                            (script[i + 4] as usize)
-                        ));
-                        if i + 5 + len <= script.len() {
-                            ret.push_str("0x");
-                            ret.push_str(&hex::encode(&script[i + 5..i + 5 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_NOP => ret.push_str("OP_NOP"),
-                OP_VER => ret.push_str("OP_VER"),
-                OP_IF => ret.push_str("OP_IF"),
-                OP_NOTIF => ret.push_str("OP_NOTIF"),
-                OP_VERIF => ret.push_str("OP_VERIF"),
-                OP_VERNOTIF => ret.push_str("OP_VERNOTIF"),
-                OP_ELSE => ret.push_str("OP_ELSE"),
-                OP_ENDIF => ret.push_str("OP_ENDIF"),
-                OP_VERIFY => ret.push_str("OP_VERIFY"),
-                OP_RETURN => ret.push_str("OP_RETURN"),
-                OP_TOALTSTACK => ret.push_str("OP_TOALTSTACK"),
-                OP_FROMALTSTACK => ret.push_str("OP_FROMALTSTACK"),
-                OP_IFDUP => ret.push_str("OP_IFDUP"),
-                OP_DEPTH => ret.push_str("OP_DEPTH"),
-                OP_DROP => ret.push_str("OP_DROP"),
-                OP_DUP => ret.push_str("OP_DUP"),
-                OP_NIP => ret.push_str("OP_NIP"),
-                OP_OVER => ret.push_str("OP_OVER"),
-                OP_PICK => ret.push_str("OP_PICK"),
-                OP_ROLL => ret.push_str("OP_ROLL"),
-                OP_ROT => ret.push_str("OP_ROT"),
-                OP_SWAP => ret.push_str("OP_SWAP"),
-                OP_TUCK => ret.push_str("OP_TUCK"),
-                OP_2DROP => ret.push_str("OP_2DROP"),
-                OP_2DUP => ret.push_str("OP_2DUP"),
-                OP_3DUP => ret.push_str("OP_3DUP"),
-                OP_2OVER => ret.push_str("OP_2OVER"),
-                OP_2ROT => ret.push_str("OP_2ROT"),
-                OP_2SWAP => ret.push_str("OP_2SWAP"),
-                OP_CAT => ret.push_str("OP_CAT"),
-                OP_SPLIT => ret.push_str("OP_SPLIT"),
-                OP_SUBSTR => ret.push_str("OP_SUBSTR"),
-                OP_LEFT => ret.push_str("OP_LEFT"),
-                OP_RIGHT => ret.push_str("OP_RIGHT"),
-                OP_SIZE => ret.push_str("OP_SIZE"),
-                OP_AND => ret.push_str("OP_AND"),
-                OP_OR => ret.push_str("OP_OR"),
-                OP_XOR => ret.push_str("OP_XOR"),
-                OP_EQUAL => ret.push_str("OP_EQUAL"),
-                OP_EQUALVERIFY => ret.push_str("OP_EQUALVERIFY"),
-                OP_1ADD => ret.push_str("OP_1ADD"),
-                OP_1SUB => ret.push_str("OP_1SUB"),
-
-                OP_NEGATE => ret.push_str("OP_NEGATE"),
-                OP_ABS => ret.push_str("OP_ABS"),
-                OP_NOT => ret.push_str("OP_NOT"),
-                OP_0NOTEQUAL => ret.push_str("OP_0NOTEQUAL"),
-
-                OP_ADD => ret.push_str("OP_ADD"),
-                OP_SUB => ret.push_str("OP_SUB"),
-                OP_MUL => ret.push_str("OP_MUL"),
-                OP_2MUL => ret.push_str("OP_2MUL"),
-                OP_DIV => ret.push_str("OP_DIV"),
-                OP_2DIV => ret.push_str("OP_2DIV"),
-                OP_MOD => ret.push_str("OP_MOD"),
-                OP_LSHIFT => ret.push_str("OP_LSHIFT"),
-                OP_RSHIFT => ret.push_str("OP_RSHIFT"),
-                OP_LSHIFTNUM => ret.push_str("OP_LSHIFTNUM"),
-                OP_RSHIFTNUM => ret.push_str("OP_RSHIFTNUM"),
-
-                OP_BOOLAND => ret.push_str("OP_BOOLAND"),
-                OP_BOOLOR => ret.push_str("OP_BOOLOR"),
-                OP_NUMEQUAL => ret.push_str("OP_NUMEQUAL"),
-                OP_NUMEQUALVERIFY => ret.push_str("OP_NUMEQUALVERIFY"),
-                OP_NUMNOTEQUAL => ret.push_str("OP_NUMNOTEQUAL"),
-                OP_LESSTHAN => ret.push_str("OP_LESSTHAN"),
-                OP_GREATERTHAN => ret.push_str("OP_GREATERTHAN"),
-                OP_LESSTHANOREQUAL => ret.push_str("OP_LESSTHANOREQUAL"),
-                OP_GREATERTHANOREQUAL => ret.push_str("OP_GREATERTHANOREQUAL"),
-                OP_MIN => ret.push_str("OP_MIN"),
-                OP_MAX => ret.push_str("OP_MAX"),
-                OP_WITHIN => ret.push_str("OP_WITHIN"),
-                OP_NUM2BIN => ret.push_str("OP_NUM2BIN"),
-                OP_BIN2NUM => ret.push_str("OP_BIN2NUM"),
-                OP_RIPEMD160 => ret.push_str("OP_RIPEMD160"),
-                OP_SHA1 => ret.push_str("OP_SHA1"),
-                OP_SHA256 => ret.push_str("OP_SHA256"),
-                OP_HASH160 => ret.push_str("OP_HASH160"),
-                OP_HASH256 => ret.push_str("OP_HASH256"),
-                OP_CODESEPARATOR => ret.push_str("OP_CODESEPARATOR"),
-                OP_CHECKSIG => ret.push_str("OP_CHECKSIG"),
-                OP_CHECKSIGVERIFY => ret.push_str("OP_CHECKSIGVERIFY"),
-                OP_CHECKMULTISIG => ret.push_str("OP_CHECKMULTISIG"),
-                OP_CHECKMULTISIGVERIFY => ret.push_str("OP_CHECKMULTISIGVERIFY"),
-                OP_CHECKLOCKTIMEVERIFY => ret.push_str("OP_CHECKLOCKTIMEVERIFY"),
-                OP_CHECKSEQUENCEVERIFY => ret.push_str("OP_CHECKSEQUENCEVERIFY"),
-                _ => ret.push_str(&format!("{}", script[i])),
-            }
-            i = next_op(i, script);
-        }
-
-        // Add whatever is remaining if we exited early
-        if i < script.len() {
-            for item in script.iter().skip(i) {
-                ret.push_str(&format!(" {item}"));
-            }
-        }
-        ret
+        format_script(
+            &self.0,
+            ScriptFormatStyle::StringRep {
+                include_byte_offsets,
+            },
+            "",
+            "",
+        )
     }
 }
 
 impl fmt::Debug for Script {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let script = &self.0;
-        let mut ret = String::new();
-        let mut i = 0;
-        ret.push('[');
-        while i < script.len() {
-            if i != 0 {
-                ret.push(' ')
-            }
-            match script[i] {
-                OP_0 => ret.push_str("OP_0"),
-                OP_1NEGATE => ret.push_str("OP_1NEGATE"),
-                OP_1 => ret.push_str("OP_1"),
-                OP_2 => ret.push_str("OP_2"),
-                OP_3 => ret.push_str("OP_3"),
-                OP_4 => ret.push_str("OP_4"),
-                OP_5 => ret.push_str("OP_5"),
-                OP_6 => ret.push_str("OP_6"),
-                OP_7 => ret.push_str("OP_7"),
-                OP_8 => ret.push_str("OP_8"),
-                OP_9 => ret.push_str("OP_9"),
-                OP_10 => ret.push_str("OP_10"),
-                OP_11 => ret.push_str("OP_11"),
-                OP_12 => ret.push_str("OP_12"),
-                OP_13 => ret.push_str("OP_13"),
-                OP_14 => ret.push_str("OP_14"),
-                OP_15 => ret.push_str("OP_15"),
-                OP_16 => ret.push_str("OP_16"),
-                len @ 1..=75 => {
-                    ret.push_str(&format!("OP_PUSH+{len} "));
-                    if i + 1 + len as usize <= script.len() {
-                        ret.push_str(&hex::encode(&script[i + 1..i + 1 + len as usize]));
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA1 => {
-                    ret.push_str("OP_PUSHDATA1 ");
-                    if i + 2 <= script.len() {
-                        let len = script[i + 1] as usize;
-                        ret.push_str(&format!("{len} "));
-                        if i + 2 + len <= script.len() {
-                            ret.push_str(&hex::encode(&script[i + 2..i + 2 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA2 => {
-                    ret.push_str("OP_PUSHDATA2 ");
-                    if i + 3 <= script.len() {
-                        let len = (script[i + 1] as usize) + ((script[i + 2] as usize) << 8);
-                        ret.push_str(&format!("{len} "));
-                        if i + 3 + len <= script.len() {
-                            ret.push_str(&hex::encode(&script[i + 3..i + 3 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA4 => {
-                    ret.push_str("OP_PUSHDATA4 ");
-                    if i + 5 <= script.len() {
-                        let len = (script[i + 1] as usize)
-                            + ((script[i + 2] as usize) << 8)
-                            + ((script[i + 3] as usize) << 16)
-                            + ((script[i + 4] as usize) << 24);
-                        ret.push_str(&format!("{len} "));
-                        if i + 5 + len <= script.len() {
-                            ret.push_str(&hex::encode(&script[i + 5..i + 5 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_NOP => ret.push_str("OP_NOP"),
-                OP_VER => ret.push_str("OP_VER"),
-                OP_IF => ret.push_str("OP_IF"),
-                OP_NOTIF => ret.push_str("OP_NOTIF"),
-                OP_VERIF => ret.push_str("OP_VERIF"),
-                OP_VERNOTIF => ret.push_str("OP_VERNOTIF"),
-                OP_ELSE => ret.push_str("OP_ELSE"),
-                OP_ENDIF => ret.push_str("OP_ENDIF"),
-                OP_VERIFY => ret.push_str("OP_VERIFY"),
-                OP_RETURN => ret.push_str("OP_RETURN"),
-                OP_TOALTSTACK => ret.push_str("OP_TOALTSTACK"),
-                OP_FROMALTSTACK => ret.push_str("OP_FROMALTSTACK"),
-                OP_IFDUP => ret.push_str("OP_IFDUP"),
-                OP_DEPTH => ret.push_str("OP_DEPTH"),
-                OP_DROP => ret.push_str("OP_DROP"),
-                OP_DUP => ret.push_str("OP_DUP"),
-                OP_NIP => ret.push_str("OP_NIP"),
-                OP_OVER => ret.push_str("OP_OVER"),
-                OP_PICK => ret.push_str("OP_PICK"),
-                OP_ROLL => ret.push_str("OP_ROLL"),
-                OP_ROT => ret.push_str("OP_ROT"),
-                OP_SWAP => ret.push_str("OP_SWAP"),
-                OP_TUCK => ret.push_str("OP_TUCK"),
-                OP_2DROP => ret.push_str("OP_2DROP"),
-                OP_2DUP => ret.push_str("OP_2DUP"),
-                OP_3DUP => ret.push_str("OP_3DUP"),
-                OP_2OVER => ret.push_str("OP_2OVER"),
-                OP_2ROT => ret.push_str("OP_2ROT"),
-                OP_2SWAP => ret.push_str("OP_2SWAP"),
-                OP_CAT => ret.push_str("OP_CAT"),
-                OP_SPLIT => ret.push_str("OP_SPLIT"),
-                OP_SUBSTR => ret.push_str("OP_SUBSTR"),
-                OP_LEFT => ret.push_str("OP_LEFT"),
-                OP_RIGHT => ret.push_str("OP_RIGHT"),
-                OP_SIZE => ret.push_str("OP_SIZE"),
-                OP_AND => ret.push_str("OP_AND"),
-                OP_OR => ret.push_str("OP_OR"),
-                OP_XOR => ret.push_str("OP_XOR"),
-                OP_EQUAL => ret.push_str("OP_EQUAL"),
-                OP_EQUALVERIFY => ret.push_str("OP_EQUALVERIFY"),
-                OP_1ADD => ret.push_str("OP_1ADD"),
-                OP_1SUB => ret.push_str("OP_1SUB"),
-                OP_NEGATE => ret.push_str("OP_NEGATE"),
-                OP_ABS => ret.push_str("OP_ABS"),
-                OP_NOT => ret.push_str("OP_NOT"),
-                OP_0NOTEQUAL => ret.push_str("OP_0NOTEQUAL"),
-
-                OP_ADD => ret.push_str("OP_ADD"),
-                OP_SUB => ret.push_str("OP_SUB"),
-                OP_MUL => ret.push_str("OP_MUL"),
-                OP_2MUL => ret.push_str("OP_2MUL"),
-                OP_DIV => ret.push_str("OP_DIV"),
-                OP_2DIV => ret.push_str("OP_2DIV"),
-                OP_MOD => ret.push_str("OP_MOD"),
-                OP_LSHIFT => ret.push_str("OP_LSHIFT"),
-                OP_RSHIFT => ret.push_str("OP_RSHIFT"),
-                OP_LSHIFTNUM => ret.push_str("OP_LSHIFTNUM"),
-                OP_RSHIFTNUM => ret.push_str("OP_RSHIFTNUM"),
-
-                OP_BOOLAND => ret.push_str("OP_BOOLAND"),
-                OP_BOOLOR => ret.push_str("OP_BOOLOR"),
-                OP_NUMEQUAL => ret.push_str("OP_NUMEQUAL"),
-                OP_NUMEQUALVERIFY => ret.push_str("OP_NUMEQUALVERIFY"),
-                OP_NUMNOTEQUAL => ret.push_str("OP_NUMNOTEQUAL"),
-                OP_LESSTHAN => ret.push_str("OP_LESSTHAN"),
-                OP_GREATERTHAN => ret.push_str("OP_GREATERTHAN"),
-                OP_LESSTHANOREQUAL => ret.push_str("OP_LESSTHANOREQUAL"),
-                OP_GREATERTHANOREQUAL => ret.push_str("OP_GREATERTHANOREQUAL"),
-                OP_MIN => ret.push_str("OP_MIN"),
-                OP_MAX => ret.push_str("OP_MAX"),
-                OP_WITHIN => ret.push_str("OP_WITHIN"),
-                OP_NUM2BIN => ret.push_str("OP_NUM2BIN"),
-                OP_BIN2NUM => ret.push_str("OP_BIN2NUM"),
-                OP_RIPEMD160 => ret.push_str("OP_RIPEMD160"),
-                OP_SHA1 => ret.push_str("OP_SHA1"),
-                OP_SHA256 => ret.push_str("OP_SHA256"),
-                OP_HASH160 => ret.push_str("OP_HASH160"),
-                OP_HASH256 => ret.push_str("OP_HASH256"),
-                OP_CODESEPARATOR => ret.push_str("OP_CODESEPARATOR"),
-                OP_CHECKSIG => ret.push_str("OP_CHECKSIG"),
-                OP_CHECKSIGVERIFY => ret.push_str("OP_CHECKSIGVERIFY"),
-                OP_CHECKMULTISIG => ret.push_str("OP_CHECKMULTISIG"),
-                OP_CHECKMULTISIGVERIFY => ret.push_str("OP_CHECKMULTISIGVERIFY"),
-                OP_CHECKLOCKTIMEVERIFY => ret.push_str("OP_CHECKLOCKTIMEVERIFY"),
-                OP_CHECKSEQUENCEVERIFY => ret.push_str("OP_CHECKSEQUENCEVERIFY"),
-                _ => ret.push_str(&format!("{}", script[i])),
-            }
-            i = next_op(i, script);
-        }
-
-        // Add whatever is remaining if we exited early
-        if i < script.len() {
-            for item in script.iter().skip(i) {
-                ret.push_str(&format!(" {item}"));
-            }
-        }
-        ret.push(']');
-        f.write_str(&ret)
+        f.write_str(&format_script(
+            &self.0,
+            ScriptFormatStyle::Debug,
+            "[",
+            "]",
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `TxVersionChecker` / `ZVersionChecker` and wire `tx_version` through `py_script_eval`, `py_script_eval_pystack`, and new `py_script_eval_two_phase_pystack`.
- Extend Python `Context` with `tx_version` and optional `lock_script` for Chronicle two-phase eval, relaxed clean stack, and OP_VER support.
- Add `max_script_num_length()` helper in `util.py` and regression tests for Chronicle Context behavior.

## Test plan
- [x] `cargo test --all-features`
- [x] `python -m unittest test_chronicle_context.py test_chronicle_opcodes.py test_debug.py` (local maturin develop wheel)


Made with [Cursor](https://cursor.com)