### PR TITLE
Gate Chronicle validation on BSV activation height

### DIFF
--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -9,6 +9,12 @@ Implementation plan and notes for [Chronicle Release](https://docs.bsvblockchain
 | TestNet | 1,713,022 |
 | MainNet | 943,835 |
 
+**Library default:** `Tx::validate()` enables Chronicle script rules when **`tx.version > 1`**, without checking block height. This suits offline signing and mempool simulation where the confirming height is unknown.
+
+**Consensus-faithful validation:** use `Tx::validate_at_height(..., block_height, network)` or [`effective_chronicle_tx_version`](https://docs.rs/chain_gang/latest/chain_gang/chronicle/fn.effective_chronicle_tx_version.html) from `chain_gang::chronicle` to gate Chronicle rules on the documented BSV activation heights.
+
+Constants: `CHRONICLE_ACTIVATION_MAINNET`, `CHRONICLE_ACTIVATION_TESTNET`, `activation_height()`.
+
 ## Sighash routing
 
 Per [bitcoin-sv `SignatureHash`](https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/script/interpreter.cpp):
@@ -101,10 +107,19 @@ Import Chronicle helpers from one module:
 
 ```rust
 use chain_gang::chronicle::{
-    eval_two_phase, is_push_only, max_script_num_length, uses_low_s_signing,
-    uses_relaxed_malleability, uses_two_phase_eval, SIGHASH_CHRONICLE,
-    MAX_SCRIPT_NUM_LENGTH_CHRONICLE, TxVersionChecker,
+    activation_height, effective_chronicle_tx_version, eval_two_phase, is_push_only,
+    max_script_num_length, uses_low_s_signing, uses_relaxed_malleability, uses_two_phase_eval,
+    SIGHASH_CHRONICLE, CHRONICLE_ACTIVATION_MAINNET, MAX_SCRIPT_NUM_LENGTH_CHRONICLE,
+    TxVersionChecker,
 };
+use chain_gang::messages::Tx;
+use chain_gang::network::Network;
+
+// Version-only validation (default):
+// tx.validate(require_sighash_forkid, use_genesis_rules, &utxos, &pregenesis_outputs)?;
+
+// Height-aware validation:
+// tx.validate_at_height(..., CHRONICLE_ACTIVATION_MAINNET, Network::BSV_Mainnet)?;
 ```
 
 Version-only script debugging without a full transaction: `TxVersionChecker` and `ZVersionChecker` (also in `chain_gang::chronicle`).

--- a/src/chronicle.rs
+++ b/src/chronicle.rs
@@ -1,15 +1,21 @@
 //! Chronicle (Bitcoin SV) helpers for transaction and script validation.
 //!
-//! Chronicle behavior is gated on **`tx.version > 1`** in this library. See
-//! [docs/Chronicle.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/Chronicle.md)
+//! By default this library gates Chronicle on **`tx.version > 1`** only. Pass block height
+//! and network to [`effective_chronicle_tx_version`] or [`Tx::validate_at_height`] for
+//! consensus-faithful activation at documented BSV block heights.
+//!
+//! See [docs/Chronicle.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/Chronicle.md)
 //! for sighash routing, opcodes, two-phase eval, malleability rules, and script number limits.
 //!
 //! # Examples
 //!
 //! ```
 //! use chain_gang::chronicle::{
+//!     activation_height, chronicle_rules_active, effective_chronicle_tx_version,
 //!     uses_low_s_signing, uses_relaxed_malleability, uses_two_phase_eval, SIGHASH_CHRONICLE,
+//!     CHRONICLE_ACTIVATION_MAINNET,
 //! };
+//! use chain_gang::network::Network;
 //! use chain_gang::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID};
 //!
 //! assert!(uses_two_phase_eval(2));
@@ -18,7 +24,26 @@
 //! assert!(!uses_low_s_signing(
 //!     SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE
 //! ));
+//! assert_eq!(
+//!     activation_height(Network::BSV_Mainnet),
+//!     Some(CHRONICLE_ACTIVATION_MAINNET)
+//! );
+//! assert!(!chronicle_rules_active(
+//!     2,
+//!     Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+//!     Some(Network::BSV_Mainnet),
+//! ));
+//! assert_eq!(
+//!     effective_chronicle_tx_version(
+//!         2,
+//!         Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+//!         Some(Network::BSV_Mainnet),
+//!     ),
+//!     1
+//! );
 //! ```
+
+use crate::network::Network;
 
 pub use crate::script::{
     eval_two_phase, eval_two_phase_with_stack, is_push_only, max_script_num_length,
@@ -28,6 +53,58 @@ pub use crate::script::{
 };
 pub use crate::transaction::uses_low_s_signing;
 pub use crate::transaction::sighash::SIGHASH_CHRONICLE;
+
+/// Chronicle activation height on BSV mainnet.
+pub const CHRONICLE_ACTIVATION_MAINNET: u64 = 943_835;
+/// Chronicle activation height on BSV testnet (and STN).
+pub const CHRONICLE_ACTIVATION_TESTNET: u64 = 1_713_022;
+
+/// Returns the Chronicle activation height for a BSV network, if defined.
+pub fn activation_height(network: Network) -> Option<u64> {
+    match network {
+        Network::BSV_Mainnet => Some(CHRONICLE_ACTIVATION_MAINNET),
+        Network::BSV_Testnet | Network::BSV_STN => Some(CHRONICLE_ACTIVATION_TESTNET),
+        _ => None,
+    }
+}
+
+/// Whether Chronicle script rules apply for the given transaction version and optional context.
+///
+/// When `block_height` and `network` are both omitted, Chronicle is enabled for `tx.version > 1`
+/// (library default). When both are provided on a BSV network, activation height is enforced.
+pub fn chronicle_rules_active(
+    tx_version: u32,
+    block_height: Option<u64>,
+    network: Option<Network>,
+) -> bool {
+    if tx_version <= 1 {
+        return false;
+    }
+    match (block_height, network) {
+        (None, None) => true,
+        (Some(height), Some(net)) => activation_height(net)
+            .map(|threshold| height >= threshold)
+            .unwrap_or(false),
+        _ => true,
+    }
+}
+
+/// Transaction version used for Chronicle script rules after applying optional activation context.
+///
+/// Returns `1` when a `version > 1` transaction is evaluated before Chronicle activation.
+pub fn effective_chronicle_tx_version(
+    tx_version: u32,
+    block_height: Option<u64>,
+    network: Option<Network>,
+) -> u32 {
+    if chronicle_rules_active(tx_version, block_height, network) {
+        tx_version
+    } else if tx_version > 1 {
+        1
+    } else {
+        tx_version
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -45,6 +122,59 @@ mod tests {
         assert_eq!(
             max_script_num_length(&TxVersionChecker { tx_version: 2 }, 0),
             MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        );
+    }
+
+    #[test]
+    fn activation_height_bsv_networks() {
+        assert_eq!(
+            activation_height(Network::BSV_Mainnet),
+            Some(CHRONICLE_ACTIVATION_MAINNET)
+        );
+        assert_eq!(
+            activation_height(Network::BSV_Testnet),
+            Some(CHRONICLE_ACTIVATION_TESTNET)
+        );
+        assert!(activation_height(Network::BTC_Mainnet).is_none());
+    }
+
+    #[test]
+    fn chronicle_rules_version_only_by_default() {
+        assert!(chronicle_rules_active(2, None, None));
+        assert!(!chronicle_rules_active(1, None, None));
+    }
+
+    #[test]
+    fn chronicle_rules_respect_mainnet_height() {
+        assert!(!chronicle_rules_active(
+            2,
+            Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+            Some(Network::BSV_Mainnet),
+        ));
+        assert!(chronicle_rules_active(
+            2,
+            Some(CHRONICLE_ACTIVATION_MAINNET),
+            Some(Network::BSV_Mainnet),
+        ));
+    }
+
+    #[test]
+    fn effective_version_suppresses_chronicle_pre_activation() {
+        assert_eq!(
+            effective_chronicle_tx_version(
+                2,
+                Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+                Some(Network::BSV_Mainnet),
+            ),
+            1
+        );
+        assert_eq!(
+            effective_chronicle_tx_version(
+                2,
+                Some(CHRONICLE_ACTIVATION_MAINNET),
+                Some(Network::BSV_Mainnet),
+            ),
+            2
         );
     }
 }

--- a/src/messages/tx.rs
+++ b/src/messages/tx.rs
@@ -1,5 +1,7 @@
+use crate::chronicle::effective_chronicle_tx_version;
 use crate::messages::message::Payload;
 use crate::messages::{OutPoint, TxIn, TxOut, COINBASE_OUTPOINT_HASH, COINBASE_OUTPOINT_INDEX};
+use crate::network::Network;
 use crate::script::{
     eval_two_phase, is_push_only, op_codes, Script, TransactionChecker, uses_relaxed_malleability,
     uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
@@ -38,13 +40,49 @@ impl Tx {
         sha256d(&b)
     }
 
-    /// Validates a non-coinbase transaction
+    /// Validates a non-coinbase transaction using version-only Chronicle gating (`tx.version > 1`).
     pub fn validate(
         &self,
         require_sighash_forkid: bool,
         use_genesis_rules: bool,
         utxos: &LinkedHashMap<OutPoint, TxOut>,
         pregenesis_outputs: &HashSet<OutPoint>,
+    ) -> Result<(), ChainGangError> {
+        self.validate_with_context(
+            require_sighash_forkid,
+            use_genesis_rules,
+            utxos,
+            pregenesis_outputs,
+            None,
+        )
+    }
+
+    /// Validates a non-coinbase transaction with BSV Chronicle activation height enforcement.
+    pub fn validate_at_height(
+        &self,
+        require_sighash_forkid: bool,
+        use_genesis_rules: bool,
+        utxos: &LinkedHashMap<OutPoint, TxOut>,
+        pregenesis_outputs: &HashSet<OutPoint>,
+        block_height: u64,
+        network: Network,
+    ) -> Result<(), ChainGangError> {
+        self.validate_with_context(
+            require_sighash_forkid,
+            use_genesis_rules,
+            utxos,
+            pregenesis_outputs,
+            Some((block_height, network)),
+        )
+    }
+
+    fn validate_with_context(
+        &self,
+        require_sighash_forkid: bool,
+        use_genesis_rules: bool,
+        utxos: &LinkedHashMap<OutPoint, TxOut>,
+        pregenesis_outputs: &HashSet<OutPoint>,
+        chronicle_context: Option<(u64, Network)>,
     ) -> Result<(), ChainGangError> {
         // Make sure neither in or out lists are empty
         if self.inputs.is_empty() {
@@ -114,11 +152,17 @@ impl Tx {
 
         // Verify each script
         let mut sighash_cache = SigHashCache::new();
+        let (block_height, network) = match chronicle_context {
+            Some((height, net)) => (Some(height), Some(net)),
+            None => (None, None),
+        };
+        let script_version =
+            effective_chronicle_tx_version(self.version, block_height, network);
         for input in 0..self.inputs.len() {
             let tx_in = &self.inputs[input];
             let tx_out = utxos.get(&tx_in.prev_output).unwrap();
 
-            if !uses_relaxed_malleability(self.version)
+            if !uses_relaxed_malleability(script_version)
                 && !is_push_only(&tx_in.unlock_script.0)
             {
                 return Err(ChainGangError::BadData(
@@ -132,6 +176,7 @@ impl Tx {
                 input,
                 satoshis: tx_out.satoshis,
                 require_sighash_forkid,
+                script_tx_version: Some(script_version),
             };
 
             let is_pregenesis_input = pregenesis_outputs.contains(&tx_in.prev_output);
@@ -141,7 +186,7 @@ impl Tx {
                 NO_FLAGS
             };
 
-            if uses_two_phase_eval(self.version) {
+            if uses_two_phase_eval(script_version) {
                 eval_two_phase(
                     &tx_in.unlock_script.0,
                     &tx_out.lock_script.0,
@@ -472,6 +517,61 @@ mod tests {
             .is_ok());
         assert!(tx_test
             .validate(true, true, &utxos, &HashSet::new())
+            .is_err());
+    }
+
+    #[test]
+    fn validate_at_height_gates_chronicle() {
+        use crate::chronicle::CHRONICLE_ACTIVATION_MAINNET;
+        use crate::network::Network;
+
+        let utxo = (
+            OutPoint {
+                hash: Hash256([6; 32]),
+                index: 0,
+            },
+            TxOut {
+                satoshis: 100,
+                lock_script: Script(vec![op_codes::OP_5, op_codes::OP_EQUAL]),
+            },
+        );
+        let mut utxos = LinkedHashMap::new();
+        utxos.insert(utxo.0.clone(), utxo.1.clone());
+
+        let tx = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                prev_output: utxo.0.clone(),
+                unlock_script: Script(vec![op_codes::OP_2, op_codes::OP_3, op_codes::OP_ADD]),
+                sequence: 0,
+            }],
+            outputs: vec![TxOut {
+                satoshis: 90,
+                lock_script: Script(vec![]),
+            }],
+            lock_time: 0,
+        };
+
+        assert!(tx.validate(true, true, &utxos, &HashSet::new()).is_ok());
+        assert!(tx
+            .validate_at_height(
+                true,
+                true,
+                &utxos,
+                &HashSet::new(),
+                CHRONICLE_ACTIVATION_MAINNET,
+                Network::BSV_Mainnet,
+            )
+            .is_ok());
+        assert!(tx
+            .validate_at_height(
+                true,
+                true,
+                &utxos,
+                &HashSet::new(),
+                CHRONICLE_ACTIVATION_MAINNET - 1,
+                Network::BSV_Mainnet,
+            )
             .is_err());
     }
 }

--- a/src/python/py_stack.rs
+++ b/src/python/py_stack.rs
@@ -126,8 +126,6 @@ impl PyStack {
             // Convert the string to a Rust BigInt (assumption is base-10)
             let big_int = BigInt::parse_bytes(big_int_str.as_bytes(), 10)
                 .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("Failed to parse BigInt"))?;
-            let (sign, magnitude) = big_int.to_bytes_le();
-            println!("from_array -> {:?} {:?}", sign, magnitude);
             inner_stack.extend(encode_bigint(big_int));
         }
         Ok(PyStack {

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -216,6 +216,14 @@ pub struct TransactionChecker<'a> {
     pub satoshis: i64,
     /// True if the signature must have SIGHASH_FORKID present, false if not
     pub require_sighash_forkid: bool,
+    /// Override transaction version for Chronicle script rules (activation height gating).
+    pub script_tx_version: Option<u32>,
+}
+
+impl<'a> TransactionChecker<'a> {
+    fn chronicle_script_version(&self) -> u32 {
+        self.script_tx_version.unwrap_or(self.tx.version)
+    }
 }
 
 impl Checker for TransactionChecker<'_> {
@@ -248,7 +256,7 @@ impl Checker for TransactionChecker<'_> {
         let der_sig = &sig[0..sig.len() - 1];
 
         let mut signature = Signature::from_der(der_sig)?;
-        if self.tx.version > 1 {
+        if self.chronicle_script_version() > 1 {
             // Chronicle lifts the low-S rule; normalize so k256 accepts high-S encodings.
             signature = signature.normalize_s().unwrap_or(signature);
         }
@@ -258,7 +266,7 @@ impl Checker for TransactionChecker<'_> {
     }
 
     fn tx_version(&self) -> Result<i32, ChainGangError> {
-        Ok(self.tx.version as i32)
+        Ok(self.chronicle_script_version() as i32)
     }
 
     fn check_locktime(&self, locktime: i32) -> Result<bool, ChainGangError> {
@@ -415,6 +423,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: true,
+            script_tx_version: None,
         };
 
         let mut script = Script::new();
@@ -487,6 +496,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script = Script::new();
@@ -584,6 +594,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script = Script::new();
@@ -699,6 +710,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script1 = Script::new();
@@ -714,6 +726,7 @@ mod tests {
             input: 1,
             satoshis: 20,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script2 = Script::new();
@@ -840,6 +853,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script1 = Script::new();
@@ -855,6 +869,7 @@ mod tests {
             input: 1,
             satoshis: 20,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script2 = Script::new();
@@ -891,6 +906,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_err());
         }
@@ -903,6 +919,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_ok());
         }
@@ -937,6 +954,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_err());
         }
@@ -949,6 +967,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_ok());
         }


### PR DESCRIPTION
## Summary
- Add `Tx::validate_at_height` and `chain_gang::chronicle` activation helpers (`activation_height`, `chronicle_rules_active`, `effective_chronicle_tx_version`).
- Gate Chronicle script rules on documented MainNet/TestNet heights when height and network are provided; keep version-only gating as the default for `Tx::validate()`.
- Pass effective script version through `TransactionChecker.script_tx_version` for two-phase eval, malleability, and high-S handling.

## Test plan
- [x] `cargo test --all-features`
- [x] `cargo test --all-features --doc`
- [x] `validate_at_height_gates_chronicle` — functional unlock passes at activation, fails pre-activation


Made with [Cursor](https://cursor.com)