### PR TITLE
Remove debug println from PyStack

### DIFF
--- a/src/python/py_stack.rs
+++ b/src/python/py_stack.rs
@@ -126,8 +126,6 @@ impl PyStack {
             // Convert the string to a Rust BigInt (assumption is base-10)
             let big_int = BigInt::parse_bytes(big_int_str.as_bytes(), 10)
                 .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("Failed to parse BigInt"))?;
-            let (sign, magnitude) = big_int.to_bytes_le();
-            println!("from_array -> {:?} {:?}", sign, magnitude);
             inner_stack.extend(encode_bigint(big_int));
         }
         Ok(PyStack {


### PR DESCRIPTION
## Summary
- Remove leftover debug `println!` from `PyStack::single_from_array_nums`.
- Drop unused `to_bytes_le()` bindings that existed only for the debug output.

## Test plan
- [x] `cargo test --all-features`


Made with [Cursor](https://cursor.com)