### PR TITLE
Chronicle integration tests and library-vs-node docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ For documentation of the Python Classes see below.
 
 Bitcoin SV [Chronicle](https://docs.bsvblockchain.org/network-topology/nodes/sv-node/chronicle-release) support is implemented in the Rust library (`chain-gang`). See [docs/Chronicle.md](docs/Chronicle.md) for sighash routing, opcodes, two-phase script evaluation, malleability rules, and script number limits.
 
-Chronicle behavior is gated on **`tx.version > 1`** when validating transactions in Rust (`Tx.validate`). Use `version: 2` (or higher) on spending transactions to opt in.
+Chronicle behavior is gated on **`tx.version > 1`** when using `Tx.validate()` (Python or Rust). Use `version: 2` (or higher) on spending transactions to opt in. For consensus-faithful activation at documented block heights, use Rust `Tx::validate_at_height()` — see [docs/Chronicle.md](docs/Chronicle.md#library-vs-node).
 
-**Python `Context` debugger:** stepping scripts via `Context` uses the legacy single-script evaluator without transaction version. It does not perform two-phase unlock/lock evaluation or version-gated malleability rules. For Chronicle-accurate validation, use Rust `Tx.validate` or build unlock/lock scripts explicitly. `OP_VER` and related opcodes require a transaction version and will fail in `Context` unless a version-aware checker is added.
+**Python `Context` debugger:** pass optional `tx_version` and `lock_script` for Chronicle two-phase eval, relaxed clean stack, and `OP_VER`. `Context` does not enforce block-height activation; for full transaction checks use `Tx.validate()` (version-only) or Rust `validate_at_height()`.
 
 # Python Installation
 As this library is hosted on PyPi (https://pypi.org/project/tx-engine/) and is installed using:
@@ -104,17 +104,19 @@ Context has the following properties:
 * `cmds` - the commands to execute
 * `ip_start` - the byte offset of where to start executing the script from (optional)
 * `ip_limit` - the number of commands to execute before stopping (optional)
-* `z` - the hash of the transaction 
+* `z` - the hash of the transaction
+* `tx_version` - optional transaction version for Chronicle opcodes and rules (optional)
+* `lock_script` - optional lock script for Chronicle two-phase eval when `tx_version > 1` (optional)
 * `stack` - main data stack
 * `alt_stack` - seconary stack
 
 Context has the following methods:
 
-* `__init__(self, script: Script, cmds: Commands = None, ip_limit: int , z: bytes)` - constructor
+* `__init__(self, script: Script, cmds: Commands = None, ip_limit: int , z: bytes, tx_version: int = None, lock_script: Script = None)` - constructor
 * `evaluate_core(self, quiet: bool = False) -> bool` - evaluates the script/cmds using the the interpreter and returns the stacks (`tack`, `alt_stack`). if quiet is true, dont print exceptions
 * `evaluate(self, quiet: bool = False) -> bool` - executes the script and decode stack elements to numbers (`stack`, `alt_stack`). Checks `stack` is true on return. if quiet is true, dont print exceptions.
 
-Note: `evaluate` / `evaluate_core` use the legacy debugger path (see [Chronicle upgrade](#chronicle-upgrade)). They do not apply Chronicle two-phase eval or version-gated malleability rules.
+When `tx_version` and `lock_script` are set (`tx_version > 1`), Chronicle two-phase eval and relaxed clean-stack rules apply. Without `tx_version`, legacy debugger semantics are used. Block-height activation is not applied in `Context`; see [Chronicle upgrade](#chronicle-upgrade).
 
 * `get_stack(self) -> Stack` - Return the `stack` as human readable
 * `get_altstack(self) -> Stack`-  Return the `alt_stack` as human readable

--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -15,7 +15,24 @@ Implementation plan and notes for [Chronicle Release](https://docs.bsvblockchain
 
 Constants: `CHRONICLE_ACTIVATION_MAINNET`, `CHRONICLE_ACTIVATION_TESTNET`, `activation_height()`.
 
-## Sighash routing
+## Library vs node
+
+This crate is a **transaction engine**, not a full BSV node. The distinction matters for Chronicle activation:
+
+| Concern | BSV node (consensus) | This library |
+|---------|----------------------|--------------|
+| When Chronicle activates | At documented block height on each network | **`Tx::validate()`:** when `tx.version > 1` (height ignored) |
+| Height-aware validation | Always uses confirming block height | **`Tx::validate_at_height()`:** height + `Network` required |
+| Mempool / offline signing | Height may be unknown | Use `validate()` or explicit `tx.version` opt-in |
+| Non-BSV networks | N/A | `activation_height()` returns `None`; height-aware path disables Chronicle script rules |
+
+**Practical guidance**
+
+- Building or checking a Chronicle spend **before activation** or **without knowing the block**: use `validate()` and set `version > 1` to exercise Chronicle script rules intentionally.
+- Validating a transaction **as a node would at a known height** (e.g. block 943,835 on mainnet): use `validate_at_height(..., block_height, Network::BSV_Mainnet)`.
+- Python `Tx.validate()` calls the Rust `validate()` path (version-only). Use Rust bindings or add a height-aware Python wrapper if you need consensus-faithful height gating.
+
+Sighash routing (`SIGHASH_CHRONICLE`) and signing policy (`uses_low_s_signing`) follow the signature flags independent of block height.
 
 Per [bitcoin-sv `SignatureHash`](https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/script/interpreter.cpp):
 

--- a/python/src/tests/test_chronicle_tx_validate.py
+++ b/python/src/tests/test_chronicle_tx_validate.py
@@ -1,0 +1,84 @@
+""" Chronicle integration tests through Tx.validate and Context
+"""
+import unittest
+
+from tx_engine import Context, Script, Tx, TxIn, TxOut
+
+
+def display_tx_hash(tx: Tx) -> str:
+    """Return the display-order txid hex string used by TxIn.prev_tx."""
+    return bytes(reversed(bytes(tx.hash()))).hex()
+
+
+class ChronicleTxValidateTest(unittest.TestCase):
+    """ End-to-end Chronicle behavior via native Tx.validate
+    """
+
+    def _fund_and_spend(
+        self,
+        lock_script: Script,
+        unlock_script: Script,
+        spend_version: int,
+    ) -> tuple[Tx, Tx]:
+        fund = Tx(
+            version=1,
+            tx_ins=[],
+            tx_outs=[TxOut(amount=1_000, script_pubkey=lock_script)],
+        )
+        spend = Tx(
+            version=spend_version,
+            tx_ins=[
+                TxIn(
+                    display_tx_hash(fund),
+                    0,
+                    unlock_script,
+                )
+            ],
+            tx_outs=[TxOut(amount=900, script_pubkey=Script([]))],
+        )
+        return fund, spend
+
+    def test_two_phase_functional_unlock_validates(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_5 OP_EQUAL"),
+            Script.parse_string("OP_2 OP_3 OP_ADD"),
+            2,
+        )
+        self.assertIsNone(spend.validate([fund]))
+
+    def test_version_one_rejects_functional_unlock(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_5 OP_EQUAL"),
+            Script.parse_string("OP_2 OP_3 OP_ADD"),
+            1,
+        )
+        with self.assertRaises(ValueError):
+            spend.validate([fund])
+
+    def test_relaxed_clean_stack_validates_for_version_two(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_1 OP_1"),
+            Script.parse_string("OP_1"),
+            2,
+        )
+        self.assertIsNone(spend.validate([fund]))
+
+    def test_relaxed_clean_stack_rejects_version_one(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_1 OP_1"),
+            Script.parse_string("OP_1"),
+            1,
+        )
+        with self.assertRaises(ValueError):
+            spend.validate([fund])
+
+    def test_context_two_phase_matches_tx_validate_path(self):
+        unlock = Script.parse_string("OP_2 OP_3 OP_ADD")
+        lock = Script.parse_string("OP_5 OP_EQUAL")
+        self.assertTrue(
+            Context(script=unlock, lock_script=lock, tx_version=2).evaluate()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -83,6 +83,8 @@ mod reject;
 mod send_cmpct;
 mod streamack;
 mod tx;
+#[cfg(test)]
+mod tx_chronicle_validate;
 mod tx_in;
 mod tx_out;
 mod version;

--- a/src/messages/tx_chronicle_validate.rs
+++ b/src/messages/tx_chronicle_validate.rs
@@ -1,0 +1,280 @@
+//! Integration tests for Chronicle rules through `Tx::validate`.
+
+use super::{OutPoint, Tx, TxIn, TxOut};
+use crate::chronicle::CHRONICLE_ACTIVATION_MAINNET;
+use crate::network::Network;
+use crate::script::op_codes::*;
+use crate::script::Script;
+use crate::transaction::sighash::{sighash, SigHashCache, SIGHASH_ALL, SIGHASH_CHRONICLE, SIGHASH_FORKID};
+use crate::util::hash160;
+use k256::ecdsa::signature::hazmat::PrehashSigner;
+use k256::ecdsa::signature::SignatureEncoding;
+use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
+use linked_hash_map::LinkedHashMap;
+use num_bigint::BigUint;
+use std::collections::HashSet;
+
+const SECP256K1_N: &str = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141";
+
+fn utxos_for_funding(funding: &Tx) -> LinkedHashMap<OutPoint, TxOut> {
+    let mut utxos = LinkedHashMap::new();
+    utxos.insert(
+        OutPoint {
+            hash: funding.hash(),
+            index: 0,
+        },
+        funding.outputs[0].clone(),
+    );
+    utxos
+}
+
+fn p2pkh_lock_script(public_key: &[u8; 33]) -> Script {
+    let pkh = hash160(public_key);
+    let mut lock_script = Script::new();
+    lock_script.append(OP_DUP);
+    lock_script.append(OP_HASH160);
+    lock_script.append_data(&pkh.0);
+    lock_script.append(OP_EQUALVERIFY);
+    lock_script.append(OP_CHECKSIG);
+    lock_script
+}
+
+fn flip_to_high_s(low_sig: &Signature) -> Signature {
+    let compact = low_sig.to_bytes();
+    let n = BigUint::parse_bytes(SECP256K1_N.as_bytes(), 16).unwrap();
+    let s = BigUint::from_bytes_be(&compact[32..]);
+    let high_s = &n - &s;
+    let mut high_compact = compact;
+    let high_s_bytes = high_s.to_bytes_be();
+    high_compact[64 - high_s_bytes.len()..].copy_from_slice(&high_s_bytes);
+    Signature::try_from(high_compact.as_ref()).unwrap()
+}
+
+fn verifying_key_as_bytes(verifying_key: &VerifyingKey) -> [u8; 33] {
+    verifying_key.to_sec1_bytes().to_vec()[..].try_into().unwrap()
+}
+
+#[test]
+fn chronicle_validate_two_phase_functional_unlock() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_5, OP_EQUAL]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![OP_2, OP_3, OP_ADD]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    assert!(spend.validate(true, true, &utxos, &HashSet::new()).is_ok());
+}
+
+#[test]
+fn chronicle_validate_version_one_rejects_functional_unlock() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_5, OP_EQUAL]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let spend = Tx {
+        version: 1,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![OP_2, OP_3, OP_ADD]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    assert!(spend.validate(true, true, &utxos, &HashSet::new()).is_err());
+}
+
+#[test]
+fn chronicle_validate_relaxed_clean_stack() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_1, OP_1]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+    let prev_output = OutPoint {
+        hash: funding.hash(),
+        index: 0,
+    };
+
+    let chronicle_spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: prev_output.clone(),
+            unlock_script: Script(vec![OP_1]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+    assert!(
+        chronicle_spend
+            .validate(true, true, &utxos, &HashSet::new())
+            .is_ok()
+    );
+
+    let legacy_spend = Tx {
+        version: 1,
+        inputs: vec![TxIn {
+            prev_output,
+            unlock_script: Script(vec![OP_1]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+    assert!(
+        legacy_spend
+            .validate(true, true, &utxos, &HashSet::new())
+            .is_err()
+    );
+}
+
+#[test]
+fn chronicle_validate_high_s_p2pkh() {
+    let private_key = [2; 32];
+    let secret_key = SigningKey::from_slice(&private_key).unwrap();
+    let public_key = verifying_key_as_bytes(secret_key.verifying_key());
+
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 10,
+            lock_script: p2pkh_lock_script(&public_key),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let mut spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 5,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    let sighash_type = SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE;
+    let mut cache = SigHashCache::new();
+    let lock_script = &funding.outputs[0].lock_script.0;
+    let sig_hash = sighash(&spend, 0, lock_script, 10, sighash_type, &mut cache).unwrap();
+    let low_sig = secret_key.sign_prehash(&sig_hash.0).unwrap();
+    let high_sig = flip_to_high_s(&low_sig);
+
+    let mut unlock_script = Script::new();
+    unlock_script.append_data(
+        &[high_sig.to_der().to_vec(), vec![sighash_type]].concat(),
+    );
+    unlock_script.append_data(&public_key);
+    spend.inputs[0].unlock_script = unlock_script;
+
+    assert!(spend.validate(true, true, &utxos, &HashSet::new()).is_ok());
+}
+
+#[test]
+fn chronicle_validate_at_height_rejects_pre_activation_spend() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_5, OP_EQUAL]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![OP_2, OP_3, OP_ADD]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    assert!(spend
+        .validate_at_height(
+            true,
+            true,
+            &utxos,
+            &HashSet::new(),
+            CHRONICLE_ACTIVATION_MAINNET,
+            Network::BSV_Mainnet,
+        )
+        .is_ok());
+    assert!(spend
+        .validate_at_height(
+            true,
+            true,
+            &utxos,
+            &HashSet::new(),
+            CHRONICLE_ACTIVATION_MAINNET - 1,
+            Network::BSV_Mainnet,
+        )
+        .is_err());
+}


### PR DESCRIPTION
## Summary
- Add Rust `Tx.validate` integration tests for Chronicle two-phase eval, relaxed clean stack, high-S P2PKH, and height-gated activation.
- Add Python `test_chronicle_tx_validate.py` mirroring key `Tx.validate` paths through the native module.
- Document library vs node activation semantics in `docs/Chronicle.md` and update README Chronicle/Context sections.

## Test plan
- [x] `cargo test --all-features tx_chronicle_validate`
- [x] `python -m unittest test_chronicle_tx_validate.py test_chronicle_context.py`


Made with [Cursor](https://cursor.com)