### PR TITLE
Chronicle stack: Phase 6, Python parity, and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ crate-type = ["cdylib", "lib"]
 opt-level = "s"     # Optimize for size over speed
 lto = true          # Enable link-time optimizations to shrink binary
 
-["features"]
+[features]
 default = ["dep:serde", "dep:serde_json"]
 interface = ["dep:serde", "dep:serde_json", "dep:reqwest", "dep:async-mutex", "dep:async-trait"]
 python = ["dep:serde", "dep:serde_json", "dep:pyo3"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ This library provides a Python interface for building BitcoinSV scripts and tran
 
 For documentation of the Python Classes see below.
 
+## Chronicle upgrade
+
+Bitcoin SV [Chronicle](https://docs.bsvblockchain.org/network-topology/nodes/sv-node/chronicle-release) support is implemented in the Rust library (`chain-gang`). See [docs/Chronicle.md](docs/Chronicle.md) for sighash routing, opcodes, two-phase script evaluation, malleability rules, and script number limits.
+
+Chronicle behavior is gated on **`tx.version > 1`** when validating transactions in Rust (`Tx.validate`). Use `version: 2` (or higher) on spending transactions to opt in.
+
+**Python `Context` debugger:** stepping scripts via `Context` uses the legacy single-script evaluator without transaction version. It does not perform two-phase unlock/lock evaluation or version-gated malleability rules. For Chronicle-accurate validation, use Rust `Tx.validate` or build unlock/lock scripts explicitly. `OP_VER` and related opcodes require a transaction version and will fail in `Context` unless a version-aware checker is added.
+
 # Python Installation
 As this library is hosted on PyPi (https://pypi.org/project/tx-engine/) and is installed using:
 
@@ -105,6 +113,9 @@ Context has the following methods:
 * `__init__(self, script: Script, cmds: Commands = None, ip_limit: int , z: bytes)` - constructor
 * `evaluate_core(self, quiet: bool = False) -> bool` - evaluates the script/cmds using the the interpreter and returns the stacks (`tack`, `alt_stack`). if quiet is true, dont print exceptions
 * `evaluate(self, quiet: bool = False) -> bool` - executes the script and decode stack elements to numbers (`stack`, `alt_stack`). Checks `stack` is true on return. if quiet is true, dont print exceptions.
+
+Note: `evaluate` / `evaluate_core` use the legacy debugger path (see [Chronicle upgrade](#chronicle-upgrade)). They do not apply Chronicle two-phase eval or version-gated malleability rules.
+
 * `get_stack(self) -> Stack` - Return the `stack` as human readable
 * `get_altstack(self) -> Stack`-  Return the `alt_stack` as human readable
 * `set_ip_start(self, start: int)` - sets the start location for the intepreter. 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ For documentation of the Python Classes see below.
 
 Bitcoin SV [Chronicle](https://docs.bsvblockchain.org/network-topology/nodes/sv-node/chronicle-release) support is implemented in the Rust library (`chain-gang`). See [docs/Chronicle.md](docs/Chronicle.md) for sighash routing, opcodes, two-phase script evaluation, malleability rules, and script number limits.
 
-Chronicle behavior is gated on **`tx.version > 1`** when validating transactions in Rust (`Tx.validate`). Use `version: 2` (or higher) on spending transactions to opt in.
+Chronicle behavior is gated on **`tx.version > 1`** when using `Tx.validate()` (Python or Rust). Use `version: 2` (or higher) on spending transactions to opt in. For consensus-faithful activation at documented block heights, use Rust `Tx::validate_at_height()` — see [docs/Chronicle.md](docs/Chronicle.md#library-vs-node).
 
-**Python `Context` debugger:** stepping scripts via `Context` uses the legacy single-script evaluator without transaction version. It does not perform two-phase unlock/lock evaluation or version-gated malleability rules. For Chronicle-accurate validation, use Rust `Tx.validate` or build unlock/lock scripts explicitly. `OP_VER` and related opcodes require a transaction version and will fail in `Context` unless a version-aware checker is added.
+**Python `Context` debugger:** pass optional `tx_version` and `lock_script` for Chronicle two-phase eval, relaxed clean stack, and `OP_VER`. `Context` does not enforce block-height activation; for full transaction checks use `Tx.validate()` (version-only) or Rust `validate_at_height()`.
 
 # Python Installation
 As this library is hosted on PyPi (https://pypi.org/project/tx-engine/) and is installed using:
@@ -104,17 +104,19 @@ Context has the following properties:
 * `cmds` - the commands to execute
 * `ip_start` - the byte offset of where to start executing the script from (optional)
 * `ip_limit` - the number of commands to execute before stopping (optional)
-* `z` - the hash of the transaction 
+* `z` - the hash of the transaction
+* `tx_version` - optional transaction version for Chronicle opcodes and rules (optional)
+* `lock_script` - optional lock script for Chronicle two-phase eval when `tx_version > 1` (optional)
 * `stack` - main data stack
 * `alt_stack` - seconary stack
 
 Context has the following methods:
 
-* `__init__(self, script: Script, cmds: Commands = None, ip_limit: int , z: bytes)` - constructor
+* `__init__(self, script: Script, cmds: Commands = None, ip_limit: int , z: bytes, tx_version: int = None, lock_script: Script = None)` - constructor
 * `evaluate_core(self, quiet: bool = False) -> bool` - evaluates the script/cmds using the the interpreter and returns the stacks (`tack`, `alt_stack`). if quiet is true, dont print exceptions
 * `evaluate(self, quiet: bool = False) -> bool` - executes the script and decode stack elements to numbers (`stack`, `alt_stack`). Checks `stack` is true on return. if quiet is true, dont print exceptions.
 
-Note: `evaluate` / `evaluate_core` use the legacy debugger path (see [Chronicle upgrade](#chronicle-upgrade)). They do not apply Chronicle two-phase eval or version-gated malleability rules.
+When `tx_version` and `lock_script` are set (`tx_version > 1`), Chronicle two-phase eval and relaxed clean-stack rules apply. Without `tx_version`, legacy debugger semantics are used. Block-height activation is not applied in `Context`; see [Chronicle upgrade](#chronicle-upgrade).
 
 * `get_stack(self) -> Stack` - Return the `stack` as human readable
 * `get_altstack(self) -> Stack`-  Return the `alt_stack` as human readable

--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -15,7 +15,24 @@ Implementation plan and notes for [Chronicle Release](https://docs.bsvblockchain
 
 Constants: `CHRONICLE_ACTIVATION_MAINNET`, `CHRONICLE_ACTIVATION_TESTNET`, `activation_height()`.
 
-## Sighash routing
+## Library vs node
+
+This crate is a **transaction engine**, not a full BSV node. The distinction matters for Chronicle activation:
+
+| Concern | BSV node (consensus) | This library |
+|---------|----------------------|--------------|
+| When Chronicle activates | At documented block height on each network | **`Tx::validate()`:** when `tx.version > 1` (height ignored) |
+| Height-aware validation | Always uses confirming block height | **`Tx::validate_at_height()`:** height + `Network` required |
+| Mempool / offline signing | Height may be unknown | Use `validate()` or explicit `tx.version` opt-in |
+| Non-BSV networks | N/A | `activation_height()` returns `None`; height-aware path disables Chronicle script rules |
+
+**Practical guidance**
+
+- Building or checking a Chronicle spend **before activation** or **without knowing the block**: use `validate()` and set `version > 1` to exercise Chronicle script rules intentionally.
+- Validating a transaction **as a node would at a known height** (e.g. block 943,835 on mainnet): use `validate_at_height(..., block_height, Network::BSV_Mainnet)`.
+- Python `Tx.validate()` calls the Rust `validate()` path (version-only). Use Rust bindings or add a height-aware Python wrapper if you need consensus-faithful height gating.
+
+Sighash routing (`SIGHASH_CHRONICLE`) and signing policy (`uses_low_s_signing`) follow the signature flags independent of block height.
 
 Per [bitcoin-sv `SignatureHash`](https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/script/interpreter.cpp):
 

--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -19,7 +19,7 @@ Per [bitcoin-sv `SignatureHash`](https://github.com/bitcoin-sv/bitcoin-sv/blob/m
 | `SIGHASH_CHRONICLE` set | OTDA (Original Transaction Digest Algorithm) |
 | Neither | OTDA (pre-fork legacy) |
 
-Constants in Rust: `SIGHASH_CHRONICLE = 0x20` in `src/transaction/sighash.rs`.
+Constants and signing policy: `SIGHASH_CHRONICLE`, `uses_low_s_signing()` — re-exported from `chain_gang::chronicle` (also in `src/transaction/sighash.rs` and `src/transaction/mod.rs`).
 
 Python: `SIGHASH.CHRONICLE` and `SIGHASH.ALL_FORKID_CHRONICLE` in `python/src/tx_engine/tx/sighash.py`.
 
@@ -32,7 +32,7 @@ Per the Chronicle spec, the low-S requirement is removed for transactions with `
 | Without `SIGHASH_CHRONICLE` | Signatures are normalized to low-S (BIP146) |
 | With `SIGHASH_CHRONICLE` | Raw signer output is preserved (high-S allowed) |
 
-Rust: `uses_low_s_signing()` and `generate_signature()` in `src/transaction/mod.rs`.
+Rust: `uses_low_s_signing()` and `generate_signature()` in `src/transaction/mod.rs` (see `chain_gang::chronicle`).
 
 Note: k256's deterministic signer currently returns low-S; the Chronicle path matters when encoding externally produced signatures or future signing backends.
 
@@ -67,7 +67,7 @@ Legacy transactions (`version == 1`) continue to concatenate `unlock + OP_CODESE
 
 CHECKSIG `scriptCode` in the unlock phase spans from the last `OP_CODESEPARATOR` in the unlock script through the end of the lock script (code separators stripped). CHECKSIG in the lock phase uses only the lock script from its last `OP_CODESEPARATOR`.
 
-Rust: `uses_two_phase_eval()`, `eval_two_phase()` in `src/script/interpreter.rs`; routed from `Tx::validate()` in `src/messages/tx.rs`.
+Rust: `uses_two_phase_eval()`, `eval_two_phase()` — re-exported from `chain_gang::chronicle`; routed from `Tx::validate()` in `src/messages/tx.rs`.
 
 ## Malleability relaxation
 
@@ -85,15 +85,29 @@ For transactions with `version > 1`, Chronicle relaxes malleability-related scri
 
 Rules apply when the checker provides a transaction version (`TransactionChecker`). Context-free script evaluation preserves prior behavior.
 
-Rust: `uses_relaxed_malleability()`, `is_push_only()` in `src/script/interpreter.rs`.
+Rust: `uses_relaxed_malleability()`, `is_push_only()` — re-exported from `chain_gang::chronicle`.
 
 ## Script number limit
 
 The maximum encoded script number size increases from 750 KB to 32 MB for Chronicle transactions (`tx.version > 1`). Pre-genesis inputs (`PREGENESIS_RULES`) keep the 4-byte limit; post-genesis `version == 1` transactions keep 750 KB.
 
-Rust: `max_script_num_length()`, `MAX_SCRIPT_NUM_LENGTH_*` in `src/script/stack.rs`; enforced in `core_eval()` via `pop_bigint_checked()` and `OP_BIN2NUM` / `OP_NUM2BIN`.
+Rust: `max_script_num_length()`, `MAX_SCRIPT_NUM_LENGTH_*` — re-exported from `chain_gang::chronicle`; enforced in `core_eval()` via `pop_bigint_checked()` and `OP_BIN2NUM` / `OP_NUM2BIN`.
 
 Python: `MAX_SCRIPT_NUM_LENGTH_CHRONICLE` in `python/src/tx_engine/engine/util.py`.
+
+## Rust API
+
+Import Chronicle helpers from one module:
+
+```rust
+use chain_gang::chronicle::{
+    eval_two_phase, is_push_only, max_script_num_length, uses_low_s_signing,
+    uses_relaxed_malleability, uses_two_phase_eval, SIGHASH_CHRONICLE,
+    MAX_SCRIPT_NUM_LENGTH_CHRONICLE, TxVersionChecker,
+};
+```
+
+Version-only script debugging without a full transaction: `TxVersionChecker` and `ZVersionChecker` (also in `chain_gang::chronicle`).
 
 ## Implementation status
 

--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -87,6 +87,14 @@ Rules apply when the checker provides a transaction version (`TransactionChecker
 
 Rust: `uses_relaxed_malleability()`, `is_push_only()` in `src/script/interpreter.rs`.
 
+## Script number limit
+
+The maximum encoded script number size increases from 750 KB to 32 MB for Chronicle transactions (`tx.version > 1`). Pre-genesis inputs (`PREGENESIS_RULES`) keep the 4-byte limit; post-genesis `version == 1` transactions keep 750 KB.
+
+Rust: `max_script_num_length()`, `MAX_SCRIPT_NUM_LENGTH_*` in `src/script/stack.rs`; enforced in `core_eval()` via `pop_bigint_checked()` and `OP_BIN2NUM` / `OP_NUM2BIN`.
+
+Python: `MAX_SCRIPT_NUM_LENGTH_CHRONICLE` in `python/src/tx_engine/engine/util.py`.
+
 ## Implementation status
 
 - [x] OTDA sighash routing (`SIGHASH_CHRONICLE`)
@@ -96,7 +104,7 @@ Rust: `uses_relaxed_malleability()`, `is_push_only()` in `src/script/interpreter
 - [x] Chronicle opcodes (OP_VER, OP_SUBSTR, OP_LEFT, OP_RIGHT, OP_LSHIFTNUM, OP_RSHIFTNUM)
 - [x] Two-phase unlock/lock script evaluation (`tx.version > 1`)
 - [x] Version-gated malleability relaxation (`tx.version > 1`)
-- [ ] 32 MB script number limit
+- [x] 32 MB script number limit (`tx.version > 1`)
 
 ## References
 

--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -9,6 +9,12 @@ Implementation plan and notes for [Chronicle Release](https://docs.bsvblockchain
 | TestNet | 1,713,022 |
 | MainNet | 943,835 |
 
+**Library default:** `Tx::validate()` enables Chronicle script rules when **`tx.version > 1`**, without checking block height. This suits offline signing and mempool simulation where the confirming height is unknown.
+
+**Consensus-faithful validation:** use `Tx::validate_at_height(..., block_height, network)` or [`effective_chronicle_tx_version`](https://docs.rs/chain_gang/latest/chain_gang/chronicle/fn.effective_chronicle_tx_version.html) from `chain_gang::chronicle` to gate Chronicle rules on the documented BSV activation heights.
+
+Constants: `CHRONICLE_ACTIVATION_MAINNET`, `CHRONICLE_ACTIVATION_TESTNET`, `activation_height()`.
+
 ## Sighash routing
 
 Per [bitcoin-sv `SignatureHash`](https://github.com/bitcoin-sv/bitcoin-sv/blob/master/src/script/interpreter.cpp):
@@ -101,10 +107,19 @@ Import Chronicle helpers from one module:
 
 ```rust
 use chain_gang::chronicle::{
-    eval_two_phase, is_push_only, max_script_num_length, uses_low_s_signing,
-    uses_relaxed_malleability, uses_two_phase_eval, SIGHASH_CHRONICLE,
-    MAX_SCRIPT_NUM_LENGTH_CHRONICLE, TxVersionChecker,
+    activation_height, effective_chronicle_tx_version, eval_two_phase, is_push_only,
+    max_script_num_length, uses_low_s_signing, uses_relaxed_malleability, uses_two_phase_eval,
+    SIGHASH_CHRONICLE, CHRONICLE_ACTIVATION_MAINNET, MAX_SCRIPT_NUM_LENGTH_CHRONICLE,
+    TxVersionChecker,
 };
+use chain_gang::messages::Tx;
+use chain_gang::network::Network;
+
+// Version-only validation (default):
+// tx.validate(require_sighash_forkid, use_genesis_rules, &utxos, &pregenesis_outputs)?;
+
+// Height-aware validation:
+// tx.validate_at_height(..., CHRONICLE_ACTIVATION_MAINNET, Network::BSV_Mainnet)?;
 ```
 
 Version-only script debugging without a full transaction: `TxVersionChecker` and `ZVersionChecker` (also in `chain_gang::chronicle`).

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -23,6 +23,7 @@ BSV only Features
 * Wallet key derivation and mnemonic parsing
 * Various Bitcoin primitives
 * Genesis upgrade support
+* [Chronicle upgrade](Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules)
 
 `Chain-gang` is based on `Rust-SV` An open source library to build Bitcoin SV applications and infrastructure in Rust. The documentation for `Rust-SV` can be found here: 
 [Rust-SV Documentation](https://docs.rs/sv/)

--- a/python/src/tests/test_chronicle_context.py
+++ b/python/src/tests/test_chronicle_context.py
@@ -1,0 +1,38 @@
+""" Chronicle Python Context parity tests
+"""
+import unittest
+
+from tx_engine import Context, Script
+from tx_engine.engine.util import max_script_num_length, MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+
+
+class ChronicleContextTest(unittest.TestCase):
+    """ Chronicle rules exposed through Python Context and util helpers
+    """
+
+    def test_op_ver_with_tx_version(self):
+        script = Script.parse_string("OP_VER OP_2 OP_NUMEQUAL")
+        self.assertTrue(Context(script=script, tx_version=2).evaluate())
+        self.assertFalse(Context(script=script, tx_version=1).evaluate())
+
+    def test_two_phase_carries_stack(self):
+        unlock = Script.parse_string("OP_2 OP_3 OP_ADD")
+        lock = Script.parse_string("OP_5 OP_EQUAL")
+        self.assertTrue(
+            Context(script=unlock, lock_script=lock, tx_version=2).evaluate()
+        )
+
+    def test_relaxed_clean_stack(self):
+        script = Script.parse_string("OP_1 OP_2 OP_1")
+        self.assertFalse(Context(script=script, tx_version=1).evaluate())
+        self.assertTrue(Context(script=script, tx_version=2).evaluate())
+
+    def test_max_script_num_length(self):
+        self.assertEqual(max_script_num_length(1), 750_000)
+        self.assertEqual(max_script_num_length(2), MAX_SCRIPT_NUM_LENGTH_CHRONICLE)
+        self.assertEqual(max_script_num_length(None), 750_000)
+        self.assertEqual(max_script_num_length(2, pregenesis=True), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/tests/test_chronicle_tx_validate.py
+++ b/python/src/tests/test_chronicle_tx_validate.py
@@ -1,0 +1,84 @@
+""" Chronicle integration tests through Tx.validate and Context
+"""
+import unittest
+
+from tx_engine import Context, Script, Tx, TxIn, TxOut
+
+
+def display_tx_hash(tx: Tx) -> str:
+    """Return the display-order txid hex string used by TxIn.prev_tx."""
+    return bytes(reversed(bytes(tx.hash()))).hex()
+
+
+class ChronicleTxValidateTest(unittest.TestCase):
+    """ End-to-end Chronicle behavior via native Tx.validate
+    """
+
+    def _fund_and_spend(
+        self,
+        lock_script: Script,
+        unlock_script: Script,
+        spend_version: int,
+    ) -> tuple[Tx, Tx]:
+        fund = Tx(
+            version=1,
+            tx_ins=[],
+            tx_outs=[TxOut(amount=1_000, script_pubkey=lock_script)],
+        )
+        spend = Tx(
+            version=spend_version,
+            tx_ins=[
+                TxIn(
+                    display_tx_hash(fund),
+                    0,
+                    unlock_script,
+                )
+            ],
+            tx_outs=[TxOut(amount=900, script_pubkey=Script([]))],
+        )
+        return fund, spend
+
+    def test_two_phase_functional_unlock_validates(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_5 OP_EQUAL"),
+            Script.parse_string("OP_2 OP_3 OP_ADD"),
+            2,
+        )
+        self.assertIsNone(spend.validate([fund]))
+
+    def test_version_one_rejects_functional_unlock(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_5 OP_EQUAL"),
+            Script.parse_string("OP_2 OP_3 OP_ADD"),
+            1,
+        )
+        with self.assertRaises(ValueError):
+            spend.validate([fund])
+
+    def test_relaxed_clean_stack_validates_for_version_two(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_1 OP_1"),
+            Script.parse_string("OP_1"),
+            2,
+        )
+        self.assertIsNone(spend.validate([fund]))
+
+    def test_relaxed_clean_stack_rejects_version_one(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_1 OP_1"),
+            Script.parse_string("OP_1"),
+            1,
+        )
+        with self.assertRaises(ValueError):
+            spend.validate([fund])
+
+    def test_context_two_phase_matches_tx_validate_path(self):
+        unlock = Script.parse_string("OP_2 OP_3 OP_ADD")
+        lock = Script.parse_string("OP_5 OP_EQUAL")
+        self.assertTrue(
+            Context(script=unlock, lock_script=lock, tx_version=2).evaluate()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/tests/test_debug.py
+++ b/python/src/tests/test_debug.py
@@ -34,6 +34,16 @@ class DebugTest(unittest.TestCase):
         self.assertTrue(context.evaluate())
         self.assertEqual(context.get_stack(), Stack([[1], [2], [3]]))
 
+    def test_ip_limit_with_z_matches_without_z(self):
+        """Regression: py_script_eval_pystack must pass start_at/break_at consistently when z is set."""
+        script = Script([OP_1, OP_2, OP_3, OP_4])
+        z = bytes(32)
+        without_z = Context(script=script, ip_limit=2)
+        with_z = Context(script=script, ip_limit=2, z=z)
+        self.assertTrue(without_z.evaluate_core())
+        self.assertTrue(with_z.evaluate_core())
+        self.assertEqual(without_z.get_stack(), with_z.get_stack())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/src/tests/test_verify_script.py
+++ b/python/src/tests/test_verify_script.py
@@ -1,0 +1,66 @@
+""" Tests for verify_script Chronicle helpers and RPC flag docs
+"""
+import unittest
+
+from tx_engine.interface.verify_script import (
+    CHRONICLE_ACTIVATION_MAINNET,
+    DEFAULT_NODE_VERIFYSCRIPT_FLAGS,
+    ScriptFlags,
+    activation_height,
+    chronicle_rules_active,
+    effective_chronicle_tx_version,
+    verifyscript_params,
+)
+
+
+class VerifyScriptTest(unittest.TestCase):
+    """ Chronicle helpers and verifyscript RPC payload builder
+    """
+
+    def test_chronicle_rules_version_only(self):
+        self.assertTrue(chronicle_rules_active(2))
+        self.assertFalse(chronicle_rules_active(1))
+
+    def test_chronicle_rules_mainnet_height(self):
+        self.assertFalse(
+            chronicle_rules_active(2, CHRONICLE_ACTIVATION_MAINNET - 1, "mainnet")
+        )
+        self.assertTrue(
+            chronicle_rules_active(2, CHRONICLE_ACTIVATION_MAINNET, "BSV_Mainnet")
+        )
+
+    def test_effective_tx_version_pre_activation(self):
+        self.assertEqual(
+            effective_chronicle_tx_version(
+                2, CHRONICLE_ACTIVATION_MAINNET - 1, "mainnet"
+            ),
+            1,
+        )
+        self.assertEqual(
+            effective_chronicle_tx_version(2, CHRONICLE_ACTIVATION_MAINNET, "mainnet"),
+            2,
+        )
+
+    def test_activation_height_networks(self):
+        self.assertEqual(activation_height("BSV_Mainnet"), CHRONICLE_ACTIVATION_MAINNET)
+        self.assertIsNone(activation_height("BTC_Mainnet"))
+
+    def test_verifyscript_params_omits_flags_by_default(self):
+        params = verifyscript_params("abc", 0, "00", 1000)
+        self.assertNotIn("flags", params)
+        self.assertEqual(params["txo"]["height"], -1)
+
+    def test_verifyscript_params_with_node_flags(self):
+        flags = int(ScriptFlags.SCRIPT_VERIFY_P2SH | ScriptFlags.SCRIPT_GENESIS)
+        params = verifyscript_params("abc", 0, "00", 1000, script_flags=flags)
+        self.assertEqual(params["flags"], flags)
+
+    def test_default_node_flags_is_post_genesis_set(self):
+        self.assertNotEqual(DEFAULT_NODE_VERIFYSCRIPT_FLAGS, 0)
+        self.assertTrue(
+            DEFAULT_NODE_VERIFYSCRIPT_FLAGS & ScriptFlags.SCRIPT_ENABLE_SIGHASH_FORKID
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/tests/test_woc.py
+++ b/python/src/tests/test_woc.py
@@ -117,7 +117,6 @@ class WoCTests(unittest.TestCase):
             else:
                 self.assertEqual(result[k], v)
 
-    # @unittest.skip("WoC is currently returning 502 (Bad Gateway indicating server issue) for this call")
     def test_get_merkle_proof(self):
         """
         curl --location --request GET  "https://api.whatsonchain.com/v1/bsv/test/tx/6106903f0e8e905b749b73d2a7239a22d2f06faf95f66e2ee4db77d875bf7bea/proof/tsc"

--- a/python/src/tx_engine/engine/context.py
+++ b/python/src/tx_engine/engine/context.py
@@ -3,18 +3,34 @@
 
 from typing import Optional, List
 
-from tx_engine.tx_engine import py_script_eval_pystack, Script, Stack
+from tx_engine.tx_engine import (
+    py_script_eval_pystack,
+    py_script_eval_two_phase_pystack,
+    Script,
+    Stack,
+)
+from tx_engine.engine.util import decode_num
 
 
 class Context:
     """ This class captures an execution context for the script
     """
-    def __init__(self, script: None | Script = None, ip_start: None | int = None, ip_limit: None | int = None, z: None | bytes = None):
+    def __init__(
+        self,
+        script: None | Script = None,
+        ip_start: None | int = None,
+        ip_limit: None | int = None,
+        z: None | bytes = None,
+        tx_version: None | int = None,
+        lock_script: None | Script = None,
+    ):
         """ Intial setup
         """
         self.ip_start: Optional[int]
         self.ip_limit: Optional[int]
         self.z: Optional[bytes]
+        self.tx_version: Optional[int]
+        self.lock_cmds: Optional[List[int]]
         self.stack: Stack = Stack()
         self.alt_stack: Stack = Stack()
 
@@ -26,6 +42,8 @@ class Context:
         self.ip_start = ip_start if ip_start else None
         self.ip_limit = ip_limit if ip_limit else None
         self.z = z if z else None
+        self.tx_version = tx_version if tx_version is not None else None
+        self.lock_cmds = lock_script.get_commands() if lock_script else None
 
     def set_commands(self, script: Script) -> None:
         """ Set the commands
@@ -38,15 +56,48 @@ class Context:
         self.stack = Stack()
         self.alt_stack = Stack()
 
+    def _uses_two_phase(self) -> bool:
+        return (
+            self.lock_cmds is not None
+            and self.tx_version is not None
+            and self.tx_version > 1
+        )
+
+    def _stack_top_is_true(self) -> bool:
+        if self.stack.size() == 0:
+            return False
+        top = self.stack[self.stack.size() - 1]
+        if top == b"" or top == []:
+            return False
+        return decode_num(top) != 0
+
     def evaluate_core(self, quiet: bool = False) -> bool:
         """Evaluate script opcodes and update stack/alt_stack.
 
-        Uses the legacy single-phase evaluator without transaction version.
-        For Chronicle rules (two-phase eval, malleability), use Rust Tx.validate.
+        When ``tx_version > 1`` and ``lock_script`` is set, uses Chronicle two-phase
+        unlock/lock evaluation. Pass ``tx_version`` for Chronicle opcodes such as OP_VER.
         """
 
         try:
-            (self.stack, self.alt_stack, finish_loc) = py_script_eval_pystack(self.cmds, self.ip_start, self.ip_limit, self.z, self.stack, self.alt_stack)
+            if self._uses_two_phase():
+                (self.stack, self.alt_stack, finish_loc) = py_script_eval_two_phase_pystack(
+                    self.cmds,
+                    self.lock_cmds,
+                    self.tx_version,
+                    self.z,
+                    None,
+                    None,
+                )
+            else:
+                (self.stack, self.alt_stack, finish_loc) = py_script_eval_pystack(
+                    self.cmds,
+                    self.ip_start,
+                    self.ip_limit,
+                    self.z,
+                    self.stack,
+                    self.alt_stack,
+                    self.tx_version,
+                )
         except Exception as e:
             if not quiet:
                 print(f"script_eval exception '{e}'")
@@ -60,6 +111,17 @@ class Context:
         if not self.evaluate_core(quiet):
             return False
 
+        # Partial execution for debugging: skip final-stack policy.
+        if self.ip_limit is not None:
+            if self.stack.size() == 0:
+                return False
+            if self.get_stack()[0] == [0] or self.get_stack()[0] == []:
+                return False
+            return True
+
+        if self.tx_version is not None and self.tx_version > 1:
+            return self._stack_top_is_true()
+
         if self.stack.size() == 0:
             return False
 
@@ -68,6 +130,9 @@ class Context:
             # no entry or 0 => false.
             if self.get_stack() == Stack([[]]) or self.get_stack() == Stack([[0]]):
                 return False
+
+        if self.stack.size() != 1:
+            return False
 
         if self.get_stack()[0] == [0] or self.get_stack()[0] == []:
             return False

--- a/python/src/tx_engine/engine/context.py
+++ b/python/src/tx_engine/engine/context.py
@@ -39,8 +39,10 @@ class Context:
         self.alt_stack = Stack()
 
     def evaluate_core(self, quiet: bool = False) -> bool:
-        """ evaluate_core calls the interpreter and returns the stacks
-            if quiet is true, dont print exceptions
+        """Evaluate script opcodes and update stack/alt_stack.
+
+        Uses the legacy single-phase evaluator without transaction version.
+        For Chronicle rules (two-phase eval, malleability), use Rust Tx.validate.
         """
 
         try:

--- a/python/src/tx_engine/engine/context.py
+++ b/python/src/tx_engine/engine/context.py
@@ -57,11 +57,7 @@ class Context:
         self.alt_stack = Stack()
 
     def _uses_two_phase(self) -> bool:
-        return (
-            self.lock_cmds is not None
-            and self.tx_version is not None
-            and self.tx_version > 1
-        )
+        return self.lock_cmds is not None and self.tx_version is not None and self.tx_version > 1
 
     def _stack_top_is_true(self) -> bool:
         if self.stack.size() == 0:
@@ -122,6 +118,9 @@ class Context:
         if self.tx_version is not None and self.tx_version > 1:
             return self._stack_top_is_true()
 
+        if self.tx_version == 1 and self.stack.size() != 1:
+            return False
+
         if self.stack.size() == 0:
             return False
 
@@ -130,9 +129,6 @@ class Context:
             # no entry or 0 => false.
             if self.get_stack() == Stack([[]]) or self.get_stack() == Stack([[0]]):
                 return False
-
-        if self.stack.size() != 1:
-            return False
 
         if self.get_stack()[0] == [0] or self.get_stack()[0] == []:
             return False

--- a/python/src/tx_engine/engine/util.py
+++ b/python/src/tx_engine/engine/util.py
@@ -14,7 +14,6 @@ MAX_SCRIPT_NUM_LENGTH_CHRONICLE: Final = 32 * 1024 * 1024
 MAXIMUM_ELEMENT_SIZE: Final = MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS
 
 # Curve constants
-# perhaps we can source these from the secp256k1 library rather than here?
 PRIME_INT: Final = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
 GROUP_ORDER_INT: Final = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 HALF_GROUP_ORDER_INT: Final = GROUP_ORDER_INT // 2
@@ -22,6 +21,15 @@ Gx: Final = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798
 Gx_bytes: Final = bytes.fromhex('79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798')
 Gy: Final = 0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8
 GUncompressed: Final = "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+
+
+def max_script_num_length(tx_version: int | None = None, pregenesis: bool = False) -> int:
+    """Return the maximum encoded script-number length for the given context."""
+    if pregenesis:
+        return MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS
+    if tx_version is not None and tx_version > 1:
+        return MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+    return MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS
 
 
 def encode_num(num: int) -> bytes:
@@ -63,13 +71,15 @@ def is_minimally_encoded(element, max_element_size=MAXIMUM_ELEMENT_SIZE) -> bool
     return True
 
 
-def decode_num(element: StackElement, check_encoding=False) -> int:
+def decode_num(element: StackElement, check_encoding=False, tx_version: int | None = None) -> int:
     """ Take a byte(array), return a number
     """
     if element == b"":
         return 0
 
-    if check_encoding and not is_minimally_encoded(element):
+    if check_encoding and not is_minimally_encoded(
+        element, max_script_num_length(tx_version)
+    ):
         if isinstance(element, bytes):
             raise ValueError(f"Value is not minimally encoded: {element.hex()}")
         raise ValueError(f"Value is not minimally encoded: {element}")

--- a/python/src/tx_engine/engine/util.py
+++ b/python/src/tx_engine/engine/util.py
@@ -6,9 +6,11 @@ from .engine_types import StackElement
 
 # Maximum script number length before Genesis (equal to CScriptNum::MAXIMUM_ELEMENT_SIZE)
 MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS: Final = 4
-# Maximum script number length after Genesis
+# Maximum script number length after Genesis (750 KB)
 MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS: Final = 750 * 1000
-# Maximum size that we are using
+# Maximum script number length after Chronicle (32 MB)
+MAX_SCRIPT_NUM_LENGTH_CHRONICLE: Final = 32 * 1024 * 1024
+# Maximum size that we are using for legacy callers
 MAXIMUM_ELEMENT_SIZE: Final = MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS
 
 # Curve constants

--- a/python/src/tx_engine/interface/verify_script.py
+++ b/python/src/tx_engine/interface/verify_script.py
@@ -1,129 +1,149 @@
-""" Script Verification Flags
+"""Helpers for BSV node ``verifyscript`` RPC and Chronicle validation in chain-gang.
+
+**Local validation (chain-gang):** ``Tx.validate()`` and ``Context`` do **not** use
+``ScriptFlags``. Chronicle script rules (two-phase eval, malleability relaxation,
+32 MB script numbers, high-S verify) are gated on ``tx.version > 1``. Rust also
+supports height-aware checks via ``Tx::validate_at_height()``; Python ``Tx.validate()``
+uses version-only gating. See ``docs/Chronicle.md``.
+
+**Node RPC:** ``ScriptFlags`` documents flag bits for ``verifyscript`` calls through
+``RPCInterface`` to a bitcoin-sv node. The node applies its own Chronicle activation
+at consensus block heights; do not assume the same bitmask controls chain-gang eval.
 """
 from enum import Enum
-from typing import Dict, Any
+from typing import Any, Dict, Final, Optional
+
+# BSV Chronicle activation heights (consensus). See docs/Chronicle.md.
+CHRONICLE_ACTIVATION_MAINNET: Final = 943_835
+CHRONICLE_ACTIVATION_TESTNET: Final = 1_713_022
+
+
+def activation_height(network: Optional[str]) -> Optional[int]:
+    """Return the Chronicle activation height for a BSV network name, if known."""
+    if network is None:
+        return None
+    normalized = network.lower().replace("_", "")
+    if normalized in ("bsvmainnet", "mainnet", "main"):
+        return CHRONICLE_ACTIVATION_MAINNET
+    if normalized in ("bsvtestnet", "testnet", "test", "bsvstn", "stn"):
+        return CHRONICLE_ACTIVATION_TESTNET
+    return None
+
+
+def chronicle_rules_active(
+    tx_version: int,
+    block_height: Optional[int] = None,
+    network: Optional[str] = None,
+) -> bool:
+    """Whether Chronicle script rules apply (mirrors ``chain_gang::chronicle``).
+
+    When ``block_height`` and ``network`` are omitted, returns ``tx_version > 1``
+    (chain-gang ``Tx.validate()`` default). When both are set on a BSV network,
+    activation height is enforced.
+    """
+    if tx_version <= 1:
+        return False
+    if block_height is None and network is None:
+        return True
+    if block_height is not None and network is not None:
+        threshold = activation_height(network)
+        if threshold is None:
+            return False
+        return block_height >= threshold
+    return True
+
+
+def effective_chronicle_tx_version(
+    tx_version: int,
+    block_height: Optional[int] = None,
+    network: Optional[str] = None,
+) -> int:
+    """Script version for Chronicle rules after optional activation context."""
+    if chronicle_rules_active(tx_version, block_height, network):
+        return tx_version
+    if tx_version > 1:
+        return 1
+    return tx_version
 
 
 class ScriptFlags(int, Enum):
-    """ Script Verification flags, for details see bitcoin source code src/script/script_flags.h
+    """Bitcoin-SV node ``verifyscript`` flag bits (RPC reference only).
+
+    These flags are passed to a **node** ``verifyscript`` RPC call. They are **not**
+    used by chain-gang's Rust/Python script interpreter. For local validation, set
+    ``tx.version`` and use ``Tx.validate()`` / ``Context(tx_version=...)`` instead.
+
+    Legacy node flags such as ``CLEANSTACK``, ``MINIMALIF``, ``NULLFAIL``, and
+    ``SIGPUSHONLY`` correspond to malleability rules that chain-gang applies
+    automatically from ``tx.version`` when ``chronicle_rules_active()`` is true.
     """
+
     SCRIPT_VERIFY_NONE = 0
 
-    ''' Evaluate P2SH subscripts (softfork safe, BIP16).
-    '''
+    # Evaluate P2SH subscripts (BIP16).
     SCRIPT_VERIFY_P2SH = 1 << 0
 
-    ''' Passing a non-strict-DER signature or one with undefined hashtype to a
-        checksig operation causes script failure. Evaluating a pubkey that is not
-        (0x04 + 64 bytes) or (0x02 or 0x03 + 32 bytes) by checksig causes script
-        failure.
-    '''
+    # Strict signature and pubkey encoding (BIP62-related).
     SCRIPT_VERIFY_STRICTENC = 1 << 1
 
-    '''Passing a non-strict-DER signature to a checksig operation causes script
-        failure (softfork safe, BIP62 rule 1)
-    '''
+    # Strict DER signatures (BIP62 rule 1).
     SCRIPT_VERIFY_DERSIG = 1 << 2
 
-    '''Passing a non-strict-DER signature or one with S > order/2 to a checksig
-        operation causes script failure
-        (softfork safe, BIP62 rule 5).
-    '''
+    # Low-S signatures (BIP62 rule 5). Relaxed for Chronicle txs (version > 1) on-node.
     SCRIPT_VERIFY_LOW_S = 1 << 3
 
-    ''' verify dummy stack item consumed by CHECKMULTISIG is of zero-length
-        (softfork safe, BIP62 rule 7).
-    '''
+    # CHECKMULTISIG dummy must be empty (BIP62 rule 7). Relaxed locally when Chronicle active.
     SCRIPT_VERIFY_NULLDUMMY = 1 << 4
 
-    ''' Using a non-push operator in the scriptSig causes script failure
-        (softfork safe, BIP62 rule 2).
-    '''
+    # scriptSig must be push-only (BIP62 rule 2). Relaxed locally when Chronicle active.
     SCRIPT_VERIFY_SIGPUSHONLY = 1 << 5
 
-    ''' Require minimal encodings for all push operations (OP_0... OP_16,
-        OP_1NEGATE where possible, direct pushes up to 75 bytes, OP_PUSHDATA up
-        to 255 bytes, OP_PUSHDATA2 for anything larger). Evaluating any other
-        push causes the script to fail (BIP62 rule 3). In addition, whenever a
-        stack element is interpreted as a number, it must be of minimal length
-        (BIP62 rule 4).
-        (softfork safe)
-    '''
+    # Minimal push and number encodings (BIP62 rules 3–4). Relaxed locally when Chronicle active.
     SCRIPT_VERIFY_MINIMALDATA = 1 << 6
 
-    ''' Discourage use of NOPs reserved for upgrades (NOP1-10)
-        Provided so that nodes can avoid accepting or mining transactions
-        containing executed NOP's whose meaning may change after a soft-fork,
-        thus rendering the script invalid; with this flag set executing
-        discouraged NOPs fails the script. This verification flag will never be a
-        mandatory flag applied to scripts in a block. NOPs that are not executed,
-        e.g.  within an unexecuted IF ENDIF block, are *not* rejected.
-    '''
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS = 1 << 7
 
-    ''' Require that only a single stack element remains after evaluation. This
-        changes the success criterion from "At least one stack element must
-        remain, and when interpreted as a boolean, it must be true" to "Exactly
-        one stack element must remain, and when interpreted as a boolean, it must
-        be true".
-        (softfork safe, BIP62 rule 6)
-        Note: CLEANSTACK should never be used without P2SH or WITNESS.
-    '''
+    # Exactly one true stack item (BIP62 rule 6). Relaxed locally when Chronicle active.
     SCRIPT_VERIFY_CLEANSTACK = 1 << 8
 
-    ''' Verify CHECKLOCKTIMEVERIFY
-        See BIP65 for details.
-    '''
     SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = 1 << 9
-
-    ''' Support CHECKSEQUENCEVERIFY opcode
-
-        See BIP112 for details
-    '''
     SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = 1 << 10
 
-    '''Require the argument of OP_IF/NOTIF to be exactly 0x01 or empty vector
-    '''
+    # OP_IF/NOTIF operand must be empty or 0x01. Relaxed locally when Chronicle active.
     SCRIPT_VERIFY_MINIMALIF = 1 << 13
 
-    ''' Signature(s) must be empty vector if an CHECK(MULTI)SIG operation failed
-    '''
+    # Failed CHECK(MULTI)SIG requires empty signature. Relaxed locally when Chronicle active.
     SCRIPT_VERIFY_NULLFAIL = 1 << 14
 
-    '''Public keys in scripts must be compressed
-    '''
     SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE = 1 << 15
-
-    ''' Do we accept signature using SIGHASH_FORKID
-    '''
     SCRIPT_ENABLE_SIGHASH_FORKID = 1 << 16
-
-    '''Is Genesis enabled - transcations that is being executed is part of block that uses Geneisis rules.
-    '''
     SCRIPT_GENESIS = 1 << 18
-
-    ''' UTXO being used in this script was created *after* Genesis upgrade
-        has been activated. This activates new rules (such as original meaning of OP_RETURN)
-        This is per (input!) UTXO flag
-    '''
     SCRIPT_UTXO_AFTER_GENESIS = 1 << 19
-
-    ''' Not actual flag. Used for marking largest flag value.
-    '''
     SCRIPT_FLAG_LAST = 1 << 20
 
 
+# Typical post-Genesis BSV node verifyscript flags (not used by chain-gang eval).
+DEFAULT_NODE_VERIFYSCRIPT_FLAGS: Final = int(ScriptFlags.SCRIPT_VERIFY_P2SH | ScriptFlags.SCRIPT_VERIFY_DERSIG | ScriptFlags.SCRIPT_VERIFY_LOW_S | ScriptFlags.SCRIPT_VERIFY_NULLDUMMY | ScriptFlags.SCRIPT_VERIFY_SIGPUSHONLY | ScriptFlags.SCRIPT_VERIFY_MINIMALDATA | ScriptFlags.SCRIPT_VERIFY_CLEANSTACK | ScriptFlags.SCRIPT_VERIFY_MINIMALIF | ScriptFlags.SCRIPT_VERIFY_NULLFAIL | ScriptFlags.SCRIPT_ENABLE_SIGHASH_FORKID | ScriptFlags.SCRIPT_GENESIS)
+
+
 def verifyscript_params(
-        tx_hash: str,
-        index: int,
-        lock_script: str,
-        lock_script_amt: int,
-        block_height: int = -1,
-        script_flags: int = -1,
-        report_flags: bool = False) -> Dict[str, Any]:
-    """ Given the provided details return the verifyscript parameters as a dictionary
+    tx_hash: str,
+    index: int,
+    lock_script: str,
+    lock_script_amt: int,
+    block_height: int = -1,
+    script_flags: int = -1,
+    report_flags: bool = False,
+) -> Dict[str, Any]:
+    """Build a ``verifyscript`` RPC request payload for a bitcoin-sv node.
+
+    ``script_flags`` uses :class:`ScriptFlags` node bits. It does not configure
+    chain-gang local script evaluation; use ``Tx.validate()`` for that.
+
+    When ``script_flags`` is ``-1``, ``DEFAULT_NODE_VERIFYSCRIPT_FLAGS`` is not
+    inserted (same as before: omit flags and let the node default).
     """
-    scripts = {"tx": tx_hash, "n": index}
+    scripts: Dict[str, Any] = {"tx": tx_hash, "n": index}
     if script_flags > -1:
         scripts["flags"] = script_flags
     scripts["reportflags"] = report_flags

--- a/python/src/tx_engine/interface/woc.py
+++ b/python/src/tx_engine/interface/woc.py
@@ -17,27 +17,39 @@ def get_url(testnet: bool = True) -> str:
     return "https://api.whatsonchain.com/v1/bsv/main"
 
 
-def get_response(url: str):
+def get_response(url: str, max_retries: int = 5):
     """This is the guts of all the WoC requests.
-    Retries until successful
-    """
-    data = None
-    while True:
-        try:
-            response = requests.get(url)
-        except ConnectionError as e:
-            # Retry on connection error
-            LOGGER.warning(f"WoC ConnectionError {e}")
-            time.sleep(1)
-        else:
-            break
 
-    if response.status_code == 200:
-        data = response.json()
-        LOGGER.debug(f"data = {data}")
-    else:
+    Retries on connection errors and transient HTTP responses (429/502/503/504).
+    """
+    transient_status = {429, 502, 503, 504}
+    for attempt in range(max_retries):
+        try:
+            response = requests.get(url, timeout=30)
+        except (ConnectionError, requests.Timeout) as e:
+            LOGGER.warning(f"WoC request error for {url}: {e}")
+            if attempt + 1 >= max_retries:
+                return None
+            time.sleep(1 + attempt)
+            continue
+
+        if response.status_code == 200:
+            data = response.json()
+            LOGGER.debug(f"data = {data}")
+            return data
+
+        if response.status_code in transient_status and attempt + 1 < max_retries:
+            LOGGER.warning(
+                f"WoC HTTP {response.status_code} for {url}, retrying "
+                f"({attempt + 1}/{max_retries})"
+            )
+            time.sleep(1 + attempt)
+            continue
+
         LOGGER.debug(f"response = {response}")
-    return data
+        return None
+
+    return None
 
 
 def get_unspent_transactions(address: str, testnet: bool = True):

--- a/src/chronicle.rs
+++ b/src/chronicle.rs
@@ -1,0 +1,50 @@
+//! Chronicle (Bitcoin SV) helpers for transaction and script validation.
+//!
+//! Chronicle behavior is gated on **`tx.version > 1`** in this library. See
+//! [docs/Chronicle.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/Chronicle.md)
+//! for sighash routing, opcodes, two-phase eval, malleability rules, and script number limits.
+//!
+//! # Examples
+//!
+//! ```
+//! use chain_gang::chronicle::{
+//!     uses_low_s_signing, uses_relaxed_malleability, uses_two_phase_eval, SIGHASH_CHRONICLE,
+//! };
+//! use chain_gang::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID};
+//!
+//! assert!(uses_two_phase_eval(2));
+//! assert!(uses_relaxed_malleability(2));
+//! assert!(!uses_two_phase_eval(1));
+//! assert!(!uses_low_s_signing(
+//!     SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE
+//! ));
+//! ```
+
+pub use crate::script::{
+    eval_two_phase, eval_two_phase_with_stack, is_push_only, max_script_num_length,
+    uses_relaxed_malleability, uses_two_phase_eval, TxVersionChecker, ZVersionChecker,
+    MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,
+    MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
+};
+pub use crate::transaction::uses_low_s_signing;
+pub use crate::transaction::sighash::SIGHASH_CHRONICLE;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID};
+
+    #[test]
+    fn chronicle_reexports_match_underlying_modules() {
+        assert_eq!(SIGHASH_CHRONICLE, crate::transaction::sighash::SIGHASH_CHRONICLE);
+        assert!(uses_two_phase_eval(2));
+        assert!(uses_relaxed_malleability(2));
+        assert!(!uses_low_s_signing(
+            SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE
+        ));
+        assert_eq!(
+            max_script_num_length(&TxVersionChecker { tx_version: 2 }, 0),
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        );
+    }
+}

--- a/src/chronicle.rs
+++ b/src/chronicle.rs
@@ -1,15 +1,21 @@
 //! Chronicle (Bitcoin SV) helpers for transaction and script validation.
 //!
-//! Chronicle behavior is gated on **`tx.version > 1`** in this library. See
-//! [docs/Chronicle.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/Chronicle.md)
+//! By default this library gates Chronicle on **`tx.version > 1`** only. Pass block height
+//! and network to [`effective_chronicle_tx_version`] or [`Tx::validate_at_height`] for
+//! consensus-faithful activation at documented BSV block heights.
+//!
+//! See [docs/Chronicle.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/Chronicle.md)
 //! for sighash routing, opcodes, two-phase eval, malleability rules, and script number limits.
 //!
 //! # Examples
 //!
 //! ```
 //! use chain_gang::chronicle::{
+//!     activation_height, chronicle_rules_active, effective_chronicle_tx_version,
 //!     uses_low_s_signing, uses_relaxed_malleability, uses_two_phase_eval, SIGHASH_CHRONICLE,
+//!     CHRONICLE_ACTIVATION_MAINNET,
 //! };
+//! use chain_gang::network::Network;
 //! use chain_gang::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID};
 //!
 //! assert!(uses_two_phase_eval(2));
@@ -18,7 +24,26 @@
 //! assert!(!uses_low_s_signing(
 //!     SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE
 //! ));
+//! assert_eq!(
+//!     activation_height(Network::BSV_Mainnet),
+//!     Some(CHRONICLE_ACTIVATION_MAINNET)
+//! );
+//! assert!(!chronicle_rules_active(
+//!     2,
+//!     Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+//!     Some(Network::BSV_Mainnet),
+//! ));
+//! assert_eq!(
+//!     effective_chronicle_tx_version(
+//!         2,
+//!         Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+//!         Some(Network::BSV_Mainnet),
+//!     ),
+//!     1
+//! );
 //! ```
+
+use crate::network::Network;
 
 pub use crate::script::{
     eval_two_phase, eval_two_phase_with_stack, is_push_only, max_script_num_length,
@@ -28,6 +53,58 @@ pub use crate::script::{
 };
 pub use crate::transaction::uses_low_s_signing;
 pub use crate::transaction::sighash::SIGHASH_CHRONICLE;
+
+/// Chronicle activation height on BSV mainnet.
+pub const CHRONICLE_ACTIVATION_MAINNET: u64 = 943_835;
+/// Chronicle activation height on BSV testnet (and STN).
+pub const CHRONICLE_ACTIVATION_TESTNET: u64 = 1_713_022;
+
+/// Returns the Chronicle activation height for a BSV network, if defined.
+pub fn activation_height(network: Network) -> Option<u64> {
+    match network {
+        Network::BSV_Mainnet => Some(CHRONICLE_ACTIVATION_MAINNET),
+        Network::BSV_Testnet | Network::BSV_STN => Some(CHRONICLE_ACTIVATION_TESTNET),
+        _ => None,
+    }
+}
+
+/// Whether Chronicle script rules apply for the given transaction version and optional context.
+///
+/// When `block_height` and `network` are both omitted, Chronicle is enabled for `tx.version > 1`
+/// (library default). When both are provided on a BSV network, activation height is enforced.
+pub fn chronicle_rules_active(
+    tx_version: u32,
+    block_height: Option<u64>,
+    network: Option<Network>,
+) -> bool {
+    if tx_version <= 1 {
+        return false;
+    }
+    match (block_height, network) {
+        (None, None) => true,
+        (Some(height), Some(net)) => activation_height(net)
+            .map(|threshold| height >= threshold)
+            .unwrap_or(false),
+        _ => true,
+    }
+}
+
+/// Transaction version used for Chronicle script rules after applying optional activation context.
+///
+/// Returns `1` when a `version > 1` transaction is evaluated before Chronicle activation.
+pub fn effective_chronicle_tx_version(
+    tx_version: u32,
+    block_height: Option<u64>,
+    network: Option<Network>,
+) -> u32 {
+    if chronicle_rules_active(tx_version, block_height, network) {
+        tx_version
+    } else if tx_version > 1 {
+        1
+    } else {
+        tx_version
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -45,6 +122,59 @@ mod tests {
         assert_eq!(
             max_script_num_length(&TxVersionChecker { tx_version: 2 }, 0),
             MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        );
+    }
+
+    #[test]
+    fn activation_height_bsv_networks() {
+        assert_eq!(
+            activation_height(Network::BSV_Mainnet),
+            Some(CHRONICLE_ACTIVATION_MAINNET)
+        );
+        assert_eq!(
+            activation_height(Network::BSV_Testnet),
+            Some(CHRONICLE_ACTIVATION_TESTNET)
+        );
+        assert!(activation_height(Network::BTC_Mainnet).is_none());
+    }
+
+    #[test]
+    fn chronicle_rules_version_only_by_default() {
+        assert!(chronicle_rules_active(2, None, None));
+        assert!(!chronicle_rules_active(1, None, None));
+    }
+
+    #[test]
+    fn chronicle_rules_respect_mainnet_height() {
+        assert!(!chronicle_rules_active(
+            2,
+            Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+            Some(Network::BSV_Mainnet),
+        ));
+        assert!(chronicle_rules_active(
+            2,
+            Some(CHRONICLE_ACTIVATION_MAINNET),
+            Some(Network::BSV_Mainnet),
+        ));
+    }
+
+    #[test]
+    fn effective_version_suppresses_chronicle_pre_activation() {
+        assert_eq!(
+            effective_chronicle_tx_version(
+                2,
+                Some(CHRONICLE_ACTIVATION_MAINNET - 1),
+                Some(Network::BSV_Mainnet),
+            ),
+            1
+        );
+        assert_eq!(
+            effective_chronicle_tx_version(
+                2,
+                Some(CHRONICLE_ACTIVATION_MAINNET),
+                Some(Network::BSV_Mainnet),
+            ),
+            2
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate log;
 extern crate lazy_static;
 
 pub mod address;
+pub mod chronicle;
 pub mod messages;
 pub mod network;
 pub mod peer;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -83,6 +83,8 @@ mod reject;
 mod send_cmpct;
 mod streamack;
 mod tx;
+#[cfg(test)]
+mod tx_chronicle_validate;
 mod tx_in;
 mod tx_out;
 mod version;

--- a/src/messages/tx.rs
+++ b/src/messages/tx.rs
@@ -1,5 +1,7 @@
+use crate::chronicle::effective_chronicle_tx_version;
 use crate::messages::message::Payload;
 use crate::messages::{OutPoint, TxIn, TxOut, COINBASE_OUTPOINT_HASH, COINBASE_OUTPOINT_INDEX};
+use crate::network::Network;
 use crate::script::{
     eval_two_phase, is_push_only, op_codes, Script, TransactionChecker, uses_relaxed_malleability,
     uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
@@ -38,13 +40,49 @@ impl Tx {
         sha256d(&b)
     }
 
-    /// Validates a non-coinbase transaction
+    /// Validates a non-coinbase transaction using version-only Chronicle gating (`tx.version > 1`).
     pub fn validate(
         &self,
         require_sighash_forkid: bool,
         use_genesis_rules: bool,
         utxos: &LinkedHashMap<OutPoint, TxOut>,
         pregenesis_outputs: &HashSet<OutPoint>,
+    ) -> Result<(), ChainGangError> {
+        self.validate_with_context(
+            require_sighash_forkid,
+            use_genesis_rules,
+            utxos,
+            pregenesis_outputs,
+            None,
+        )
+    }
+
+    /// Validates a non-coinbase transaction with BSV Chronicle activation height enforcement.
+    pub fn validate_at_height(
+        &self,
+        require_sighash_forkid: bool,
+        use_genesis_rules: bool,
+        utxos: &LinkedHashMap<OutPoint, TxOut>,
+        pregenesis_outputs: &HashSet<OutPoint>,
+        block_height: u64,
+        network: Network,
+    ) -> Result<(), ChainGangError> {
+        self.validate_with_context(
+            require_sighash_forkid,
+            use_genesis_rules,
+            utxos,
+            pregenesis_outputs,
+            Some((block_height, network)),
+        )
+    }
+
+    fn validate_with_context(
+        &self,
+        require_sighash_forkid: bool,
+        use_genesis_rules: bool,
+        utxos: &LinkedHashMap<OutPoint, TxOut>,
+        pregenesis_outputs: &HashSet<OutPoint>,
+        chronicle_context: Option<(u64, Network)>,
     ) -> Result<(), ChainGangError> {
         // Make sure neither in or out lists are empty
         if self.inputs.is_empty() {
@@ -114,11 +152,17 @@ impl Tx {
 
         // Verify each script
         let mut sighash_cache = SigHashCache::new();
+        let (block_height, network) = match chronicle_context {
+            Some((height, net)) => (Some(height), Some(net)),
+            None => (None, None),
+        };
+        let script_version =
+            effective_chronicle_tx_version(self.version, block_height, network);
         for input in 0..self.inputs.len() {
             let tx_in = &self.inputs[input];
             let tx_out = utxos.get(&tx_in.prev_output).unwrap();
 
-            if !uses_relaxed_malleability(self.version)
+            if !uses_relaxed_malleability(script_version)
                 && !is_push_only(&tx_in.unlock_script.0)
             {
                 return Err(ChainGangError::BadData(
@@ -132,6 +176,7 @@ impl Tx {
                 input,
                 satoshis: tx_out.satoshis,
                 require_sighash_forkid,
+                script_tx_version: Some(script_version),
             };
 
             let is_pregenesis_input = pregenesis_outputs.contains(&tx_in.prev_output);
@@ -141,7 +186,7 @@ impl Tx {
                 NO_FLAGS
             };
 
-            if uses_two_phase_eval(self.version) {
+            if uses_two_phase_eval(script_version) {
                 eval_two_phase(
                     &tx_in.unlock_script.0,
                     &tx_out.lock_script.0,
@@ -472,6 +517,61 @@ mod tests {
             .is_ok());
         assert!(tx_test
             .validate(true, true, &utxos, &HashSet::new())
+            .is_err());
+    }
+
+    #[test]
+    fn validate_at_height_gates_chronicle() {
+        use crate::chronicle::CHRONICLE_ACTIVATION_MAINNET;
+        use crate::network::Network;
+
+        let utxo = (
+            OutPoint {
+                hash: Hash256([6; 32]),
+                index: 0,
+            },
+            TxOut {
+                satoshis: 100,
+                lock_script: Script(vec![op_codes::OP_5, op_codes::OP_EQUAL]),
+            },
+        );
+        let mut utxos = LinkedHashMap::new();
+        utxos.insert(utxo.0.clone(), utxo.1.clone());
+
+        let tx = Tx {
+            version: 2,
+            inputs: vec![TxIn {
+                prev_output: utxo.0.clone(),
+                unlock_script: Script(vec![op_codes::OP_2, op_codes::OP_3, op_codes::OP_ADD]),
+                sequence: 0,
+            }],
+            outputs: vec![TxOut {
+                satoshis: 90,
+                lock_script: Script(vec![]),
+            }],
+            lock_time: 0,
+        };
+
+        assert!(tx.validate(true, true, &utxos, &HashSet::new()).is_ok());
+        assert!(tx
+            .validate_at_height(
+                true,
+                true,
+                &utxos,
+                &HashSet::new(),
+                CHRONICLE_ACTIVATION_MAINNET,
+                Network::BSV_Mainnet,
+            )
+            .is_ok());
+        assert!(tx
+            .validate_at_height(
+                true,
+                true,
+                &utxos,
+                &HashSet::new(),
+                CHRONICLE_ACTIVATION_MAINNET - 1,
+                Network::BSV_Mainnet,
+            )
             .is_err());
     }
 }

--- a/src/messages/tx_chronicle_validate.rs
+++ b/src/messages/tx_chronicle_validate.rs
@@ -1,0 +1,280 @@
+//! Integration tests for Chronicle rules through `Tx::validate`.
+
+use super::{OutPoint, Tx, TxIn, TxOut};
+use crate::chronicle::CHRONICLE_ACTIVATION_MAINNET;
+use crate::network::Network;
+use crate::script::op_codes::*;
+use crate::script::Script;
+use crate::transaction::sighash::{sighash, SigHashCache, SIGHASH_ALL, SIGHASH_CHRONICLE, SIGHASH_FORKID};
+use crate::util::hash160;
+use k256::ecdsa::signature::hazmat::PrehashSigner;
+use k256::ecdsa::signature::SignatureEncoding;
+use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
+use linked_hash_map::LinkedHashMap;
+use num_bigint::BigUint;
+use std::collections::HashSet;
+
+const SECP256K1_N: &str = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141";
+
+fn utxos_for_funding(funding: &Tx) -> LinkedHashMap<OutPoint, TxOut> {
+    let mut utxos = LinkedHashMap::new();
+    utxos.insert(
+        OutPoint {
+            hash: funding.hash(),
+            index: 0,
+        },
+        funding.outputs[0].clone(),
+    );
+    utxos
+}
+
+fn p2pkh_lock_script(public_key: &[u8; 33]) -> Script {
+    let pkh = hash160(public_key);
+    let mut lock_script = Script::new();
+    lock_script.append(OP_DUP);
+    lock_script.append(OP_HASH160);
+    lock_script.append_data(&pkh.0);
+    lock_script.append(OP_EQUALVERIFY);
+    lock_script.append(OP_CHECKSIG);
+    lock_script
+}
+
+fn flip_to_high_s(low_sig: &Signature) -> Signature {
+    let compact = low_sig.to_bytes();
+    let n = BigUint::parse_bytes(SECP256K1_N.as_bytes(), 16).unwrap();
+    let s = BigUint::from_bytes_be(&compact[32..]);
+    let high_s = &n - &s;
+    let mut high_compact = compact;
+    let high_s_bytes = high_s.to_bytes_be();
+    high_compact[64 - high_s_bytes.len()..].copy_from_slice(&high_s_bytes);
+    Signature::try_from(high_compact.as_ref()).unwrap()
+}
+
+fn verifying_key_as_bytes(verifying_key: &VerifyingKey) -> [u8; 33] {
+    verifying_key.to_sec1_bytes().to_vec()[..].try_into().unwrap()
+}
+
+#[test]
+fn chronicle_validate_two_phase_functional_unlock() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_5, OP_EQUAL]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![OP_2, OP_3, OP_ADD]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    assert!(spend.validate(true, true, &utxos, &HashSet::new()).is_ok());
+}
+
+#[test]
+fn chronicle_validate_version_one_rejects_functional_unlock() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_5, OP_EQUAL]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let spend = Tx {
+        version: 1,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![OP_2, OP_3, OP_ADD]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    assert!(spend.validate(true, true, &utxos, &HashSet::new()).is_err());
+}
+
+#[test]
+fn chronicle_validate_relaxed_clean_stack() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_1, OP_1]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+    let prev_output = OutPoint {
+        hash: funding.hash(),
+        index: 0,
+    };
+
+    let chronicle_spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: prev_output.clone(),
+            unlock_script: Script(vec![OP_1]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+    assert!(
+        chronicle_spend
+            .validate(true, true, &utxos, &HashSet::new())
+            .is_ok()
+    );
+
+    let legacy_spend = Tx {
+        version: 1,
+        inputs: vec![TxIn {
+            prev_output,
+            unlock_script: Script(vec![OP_1]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+    assert!(
+        legacy_spend
+            .validate(true, true, &utxos, &HashSet::new())
+            .is_err()
+    );
+}
+
+#[test]
+fn chronicle_validate_high_s_p2pkh() {
+    let private_key = [2; 32];
+    let secret_key = SigningKey::from_slice(&private_key).unwrap();
+    let public_key = verifying_key_as_bytes(secret_key.verifying_key());
+
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 10,
+            lock_script: p2pkh_lock_script(&public_key),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let mut spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 5,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    let sighash_type = SIGHASH_ALL | SIGHASH_FORKID | SIGHASH_CHRONICLE;
+    let mut cache = SigHashCache::new();
+    let lock_script = &funding.outputs[0].lock_script.0;
+    let sig_hash = sighash(&spend, 0, lock_script, 10, sighash_type, &mut cache).unwrap();
+    let low_sig = secret_key.sign_prehash(&sig_hash.0).unwrap();
+    let high_sig = flip_to_high_s(&low_sig);
+
+    let mut unlock_script = Script::new();
+    unlock_script.append_data(
+        &[high_sig.to_der().to_vec(), vec![sighash_type]].concat(),
+    );
+    unlock_script.append_data(&public_key);
+    spend.inputs[0].unlock_script = unlock_script;
+
+    assert!(spend.validate(true, true, &utxos, &HashSet::new()).is_ok());
+}
+
+#[test]
+fn chronicle_validate_at_height_rejects_pre_activation_spend() {
+    let funding = Tx {
+        version: 1,
+        inputs: vec![],
+        outputs: vec![TxOut {
+            satoshis: 1_000,
+            lock_script: Script(vec![OP_5, OP_EQUAL]),
+        }],
+        lock_time: 0,
+    };
+    let utxos = utxos_for_funding(&funding);
+
+    let spend = Tx {
+        version: 2,
+        inputs: vec![TxIn {
+            prev_output: OutPoint {
+                hash: funding.hash(),
+                index: 0,
+            },
+            unlock_script: Script(vec![OP_2, OP_3, OP_ADD]),
+            sequence: 0xffffffff,
+        }],
+        outputs: vec![TxOut {
+            satoshis: 900,
+            lock_script: Script(vec![]),
+        }],
+        lock_time: 0,
+    };
+
+    assert!(spend
+        .validate_at_height(
+            true,
+            true,
+            &utxos,
+            &HashSet::new(),
+            CHRONICLE_ACTIVATION_MAINNET,
+            Network::BSV_Mainnet,
+        )
+        .is_ok());
+    assert!(spend
+        .validate_at_height(
+            true,
+            true,
+            &utxos,
+            &HashSet::new(),
+            CHRONICLE_ACTIVATION_MAINNET - 1,
+            Network::BSV_Mainnet,
+        )
+        .is_err());
+}

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -154,8 +154,8 @@ fn py_script_eval_pystack(
             script.eval_with_stack(
                 &mut ZChecker { z },
                 NO_FLAGS,
-                break_at,
                 start_at,
+                break_at,
                 main_stack,
                 alternative_stack,
             )?

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -19,7 +19,10 @@ use crate::{
             PyWallet,
         },
     },
-    script::{stack::Stack, Script, TransactionlessChecker, ZChecker, NO_FLAGS},
+    script::{
+        eval_two_phase_with_stack, stack::Stack, Script, TransactionlessChecker, TxVersionChecker,
+        ZChecker, ZVersionChecker, NO_FLAGS,
+    },
     transaction::sighash::{sig_hash_preimage, sig_hash_preimage_checksig_index, SigHashCache},
     util::{hash160, sha256d, ChainGangError, Hash256},
     wallet::{
@@ -29,6 +32,88 @@ use crate::{
 };
 
 pub type Bytes = Vec<u8>;
+
+fn parse_z_bytes(sig_hash: &[u8]) -> PyResult<Hash256> {
+    let z_array: [u8; 32] = sig_hash.try_into().map_err(|_| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>("z_bytes must be exactly 32 bytes long")
+    })?;
+    Ok(Hash256(z_array))
+}
+
+fn eval_script_with_stack(
+    script: &Script,
+    z: Option<Hash256>,
+    tx_version: Option<i32>,
+    start_at: Option<usize>,
+    break_at: Option<usize>,
+    main_stack: Option<Stack>,
+    alternative_stack: Option<Stack>,
+) -> Result<(Stack, Stack, Option<usize>), ChainGangError> {
+    match (z, tx_version) {
+        (Some(z), Some(tx_version)) => {
+            let mut checker = ZVersionChecker { z, tx_version };
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+        (Some(z), None) => {
+            let mut checker = ZChecker { z };
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+        (None, Some(tx_version)) => {
+            let mut checker = TxVersionChecker { tx_version };
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+        (None, None) => {
+            let mut checker = TransactionlessChecker {};
+            script.eval_with_stack(
+                &mut checker,
+                NO_FLAGS,
+                start_at,
+                break_at,
+                main_stack,
+                alternative_stack,
+            )
+        }
+    }
+}
+
+fn eval_two_phase_with_checker(
+    unlock: &[u8],
+    lock: &[u8],
+    z: Option<Hash256>,
+    tx_version: i32,
+) -> Result<(Stack, Stack), ChainGangError> {
+    match z {
+        Some(z) => {
+            let mut checker = ZVersionChecker { z, tx_version };
+            eval_two_phase_with_stack(unlock, lock, &mut checker, NO_FLAGS)
+        }
+        None => {
+            let mut checker = TxVersionChecker { tx_version };
+            eval_two_phase_with_stack(unlock, lock, &mut checker, NO_FLAGS)
+        }
+    }
+}
 
 #[pyfunction(name = "p2pkh_script")]
 fn py_p2pkh_pyscript(h160: &[u8]) -> PyScript {
@@ -72,55 +157,35 @@ pub fn py_public_key_to_address(public_key: &[u8], network: &str) -> PyResult<St
 ///  * py_script - the script to execute
 ///  * break_at - the instruction to stop at, or None
 ///  * z - the sig_hash of the transaction as bytes, or None
+///  * tx_version - optional transaction version for Chronicle opcodes
 #[pyfunction]
-#[pyo3(signature = (py_script, break_at=None, z=None))]
+#[pyo3(signature = (py_script, break_at=None, z=None, tx_version=None))]
 fn py_script_eval(
     py_script: &[u8],
     break_at: Option<usize>,
     z: Option<&[u8]>,
+    tx_version: Option<i32>,
 ) -> PyResult<(Stack, Stack, Option<usize>)> {
     let mut script = Script::new();
     script.append_slice(py_script);
-    // Pick the appropriate transaction checker
-    match z {
-        Some(sig_hash) => {
-            // Ensure the slice is exactly 32 bytes long
-            let z_bytes = sig_hash;
-            let z_array: [u8; 32] = match z_bytes.try_into() {
-                Ok(array) => array,
-                Err(_) => {
-                    // Handle the error if `z_bytes` is not 32 bytes long
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                        "z_bytes must be exactly 32 bytes long",
-                    ));
-                }
-            };
-
-            let z = Hash256(z_array);
-            Ok(
-                script.eval_with_stack(
-                    &mut ZChecker { z },
-                    NO_FLAGS,
-                    None,
-                    break_at,
-                    None,
-                    None,
-                )?,
-            )
-        }
-        None => Ok(script.eval_with_stack(
-            &mut TransactionlessChecker {},
-            NO_FLAGS,
-            None,
-            break_at,
-            None,
-            None,
-        )?),
-    }
+    let z_hash = match z {
+        Some(sig_hash) => Some(parse_z_bytes(sig_hash)?),
+        None => None,
+    };
+    eval_script_with_stack(
+        &script,
+        z_hash,
+        tx_version,
+        None,
+        break_at,
+        None,
+        None,
+    )
+    .map_err(Into::into)
 }
 
 #[pyfunction]
-#[pyo3(signature = (py_script, start_at=None, break_at=None, z=None, stack_param=None, alt_stack_param=None))]
+#[pyo3(signature = (py_script, start_at=None, break_at=None, z=None, stack_param=None, alt_stack_param=None, tx_version=None))]
 fn py_script_eval_pystack(
     py_script: &[u8],
     start_at: Option<usize>,
@@ -128,47 +193,25 @@ fn py_script_eval_pystack(
     z: Option<&[u8]>,
     stack_param: Option<PyStack>,
     alt_stack_param: Option<PyStack>,
+    tx_version: Option<i32>,
 ) -> PyResult<(PyStack, PyStack, Option<usize>)> {
     let mut script = Script::new();
     script.append_slice(py_script);
-    // Handle stack and alt_stack parameters with match
     let main_stack = stack_param.map(|py_stack_main| py_stack_main.to_stack());
-
     let alternative_stack = alt_stack_param.map(|alt_stack_param| alt_stack_param.to_stack());
-
-    // Pick the appropriate transaction checker
-    let (main_stack, alt_stack, prog_counter) = match z {
-        Some(sig_hash) => {
-            // Ensure the slice is exactly 32 bytes long
-            let z_bytes = sig_hash;
-            let z_array: [u8; 32] = match z_bytes.try_into() {
-                Ok(array) => array,
-                Err(_) => {
-                    // Handle the error if `z_bytes` is not 32 bytes long
-                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                        "z_bytes must be exactly 32 bytes long",
-                    ));
-                }
-            };
-            let z = Hash256(z_array);
-            script.eval_with_stack(
-                &mut ZChecker { z },
-                NO_FLAGS,
-                start_at,
-                break_at,
-                main_stack,
-                alternative_stack,
-            )?
-        }
-        None => script.eval_with_stack(
-            &mut TransactionlessChecker {},
-            NO_FLAGS,
-            start_at,
-            break_at,
-            main_stack,
-            alternative_stack,
-        )?,
+    let z_hash = match z {
+        Some(sig_hash) => Some(parse_z_bytes(sig_hash)?),
+        None => None,
     };
+    let (main_stack, alt_stack, prog_counter) = eval_script_with_stack(
+        &script,
+        z_hash,
+        tx_version,
+        start_at,
+        break_at,
+        main_stack,
+        alternative_stack,
+    )?;
 
     let optional_i = match break_at {
         Some(_) => prog_counter,
@@ -179,6 +222,42 @@ fn py_script_eval_pystack(
         PyStack::from_stack(main_stack),
         PyStack::from_stack(alt_stack),
         optional_i,
+    ))
+}
+
+/// Evaluates unlock and lock scripts in separate phases (Chronicle, `tx.version > 1`).
+#[pyfunction]
+#[pyo3(signature = (unlock, lock, tx_version, z=None, stack_param=None, alt_stack_param=None))]
+fn py_script_eval_two_phase_pystack(
+    unlock: &[u8],
+    lock: &[u8],
+    tx_version: i32,
+    z: Option<&[u8]>,
+    stack_param: Option<PyStack>,
+    alt_stack_param: Option<PyStack>,
+) -> PyResult<(PyStack, PyStack, Option<usize>)> {
+    if tx_version <= 1 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "two-phase eval requires tx_version > 1",
+        ));
+    }
+    let main_stack = stack_param.map(|py_stack_main| py_stack_main.to_stack());
+    let alternative_stack = alt_stack_param.map(|alt_stack_param| alt_stack_param.to_stack());
+    if main_stack.is_some() || alternative_stack.is_some() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "two-phase eval does not accept initial stacks",
+        ));
+    }
+    let z_hash = match z {
+        Some(sig_hash) => Some(parse_z_bytes(sig_hash)?),
+        None => None,
+    };
+    let (main_stack, alt_stack) =
+        eval_two_phase_with_checker(unlock, lock, z_hash, tx_version)?;
+    Ok((
+        PyStack::from_stack(main_stack),
+        PyStack::from_stack(alt_stack),
+        None,
     ))
 }
 
@@ -383,6 +462,7 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_generate_wif_from_pw_nonce, m)?)?;
     m.add_function(wrap_pyfunction!(decode_num_stack, m)?)?;
     m.add_function(wrap_pyfunction!(py_script_eval_pystack, m)?)?;
+    m.add_function(wrap_pyfunction!(py_script_eval_two_phase_pystack, m)?)?;
     // Script
     m.add_class::<PyScript>()?;
 

--- a/src/python/py_script.rs
+++ b/src/python/py_script.rs
@@ -63,8 +63,6 @@ fn handle_pushdata(cmd: &Command, is_pushdata: usize) -> usize {
 
 fn decode_op(op: &str, is_pushdata: usize) -> Command {
     let op = op.trim();
-    // println!("decode_op({:?})", &op);
-    // Command
     if let Some(val) = OP_CODE_NAMES.get(op) {
         return Command::Int(*val);
     }

--- a/src/python/py_stack.rs
+++ b/src/python/py_stack.rs
@@ -126,8 +126,6 @@ impl PyStack {
             // Convert the string to a Rust BigInt (assumption is base-10)
             let big_int = BigInt::parse_bytes(big_int_str.as_bytes(), 10)
                 .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("Failed to parse BigInt"))?;
-            let (sign, magnitude) = big_int.to_bytes_le();
-            println!("from_array -> {:?} {:?}", sign, magnitude);
             inner_stack.extend(encode_bigint(big_int));
         }
         Ok(PyStack {

--- a/src/python/py_stack.rs
+++ b/src/python/py_stack.rs
@@ -6,7 +6,6 @@ use pyo3::{
     types::{PyDict, PyInt, PyList},
 };
 
-//use std::ffi::CStr;
 use std::ffi::CString;
 
 #[pyclass(name = "Stack", get_all, set_all, dict)]

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -18,7 +18,6 @@ use pyo3::{
     prelude::*,
     types::{PyDict, PyInt, PyType},
 };
-//use std::ffi::CStr;
 use std::ffi::CString;
 
 use hmac::Hmac;
@@ -29,15 +28,17 @@ use rand::rngs::OsRng;
 use sha2::Sha256;
 use std::num::NonZeroU32;
 
-// TODO: note only tested for compressed key
-// Given a WIF, return bytes rather than SigningKey
+/// Decode a compressed WIF private key to 32 raw bytes.
+///
+/// Uncompressed WIF (51 characters, no trailing `0x01` suffix) is not supported here;
+/// `bytes_to_wif` always emits compressed WIF.
 pub fn wif_to_bytes(wif: &str) -> Result<Vec<u8>, ChainGangError> {
     let (_, private_key) = wif_to_network_and_private_key(wif)?;
     let private_key_as_bytes = private_key.to_bytes();
     Ok(private_key_as_bytes.to_vec())
 }
 
-// Given bytes generate a WIF (for a private key)
+/// Encode 32 private-key bytes as a compressed WIF (appends `0x01` suffix).
 pub fn bytes_to_wif(key_as_bytes: &[u8], prefix_as_bytes: u8) -> String {
     let mut wif_bytes = Vec::new();
     wif_bytes.push(prefix_as_bytes);

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -216,6 +216,14 @@ pub struct TransactionChecker<'a> {
     pub satoshis: i64,
     /// True if the signature must have SIGHASH_FORKID present, false if not
     pub require_sighash_forkid: bool,
+    /// Override transaction version for Chronicle script rules (activation height gating).
+    pub script_tx_version: Option<u32>,
+}
+
+impl<'a> TransactionChecker<'a> {
+    fn chronicle_script_version(&self) -> u32 {
+        self.script_tx_version.unwrap_or(self.tx.version)
+    }
 }
 
 impl Checker for TransactionChecker<'_> {
@@ -248,7 +256,7 @@ impl Checker for TransactionChecker<'_> {
         let der_sig = &sig[0..sig.len() - 1];
 
         let mut signature = Signature::from_der(der_sig)?;
-        if self.tx.version > 1 {
+        if self.chronicle_script_version() > 1 {
             // Chronicle lifts the low-S rule; normalize so k256 accepts high-S encodings.
             signature = signature.normalize_s().unwrap_or(signature);
         }
@@ -258,7 +266,7 @@ impl Checker for TransactionChecker<'_> {
     }
 
     fn tx_version(&self) -> Result<i32, ChainGangError> {
-        Ok(self.tx.version as i32)
+        Ok(self.chronicle_script_version() as i32)
     }
 
     fn check_locktime(&self, locktime: i32) -> Result<bool, ChainGangError> {
@@ -415,6 +423,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: true,
+            script_tx_version: None,
         };
 
         let mut script = Script::new();
@@ -487,6 +496,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script = Script::new();
@@ -584,6 +594,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script = Script::new();
@@ -699,6 +710,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script1 = Script::new();
@@ -714,6 +726,7 @@ mod tests {
             input: 1,
             satoshis: 20,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script2 = Script::new();
@@ -840,6 +853,7 @@ mod tests {
             input: 0,
             satoshis: 10,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script1 = Script::new();
@@ -855,6 +869,7 @@ mod tests {
             input: 1,
             satoshis: 20,
             require_sighash_forkid: false,
+            script_tx_version: None,
         };
 
         let mut script2 = Script::new();
@@ -891,6 +906,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_err());
         }
@@ -903,6 +919,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_ok());
         }
@@ -937,6 +954,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_err());
         }
@@ -949,6 +967,7 @@ mod tests {
                 input: 0,
                 satoshis: 0,
                 require_sighash_forkid: false,
+                script_tx_version: None,
             };
             assert!(lock_script.eval(&mut c, PREGENESIS_RULES).is_ok());
         }

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -117,6 +117,93 @@ impl Checker for ZChecker {
     }
 }
 
+/// Script checker that supplies `tx.version` for Chronicle opcodes without transaction validation.
+pub struct TxVersionChecker {
+    pub tx_version: i32,
+}
+
+impl Checker for TxVersionChecker {
+    fn check_sig(
+        &mut self,
+        _sig: &[u8],
+        _pubkey: &[u8],
+        _script: &[u8],
+    ) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn check_locktime(&self, _locktime: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn check_sequence(&self, _sequence: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn tx_version(&self) -> Result<i32, ChainGangError> {
+        Ok(self.tx_version)
+    }
+}
+
+/// Script checker that uses a provided sighash and transaction version (Chronicle debugging).
+pub struct ZVersionChecker {
+    pub z: Hash256,
+    pub tx_version: i32,
+}
+
+impl Checker for ZVersionChecker {
+    fn check_sig(
+        &mut self,
+        sig: &[u8],
+        pubkey: &[u8],
+        _script: &[u8],
+    ) -> Result<bool, ChainGangError> {
+        if sig.is_empty() {
+            return Err(ChainGangError::ScriptError(
+                "Signature too short".to_string(),
+            ));
+        }
+        let sighash_type = sig[sig.len() - 1];
+        if sighash_type & SIGHASH_FORKID == 0 {
+            return Err(ChainGangError::ScriptError(
+                "SIGHASH_FORKID not present".to_string(),
+            ));
+        }
+
+        let sig_hash = self.z;
+        let der_sig = &sig[0..sig.len() - 1];
+        let signature = Signature::from_der(der_sig)?;
+
+        let message = sig_hash.0;
+
+        let verifying_key = VerifyingKey::from_sec1_bytes(pubkey)?;
+
+        Ok(verifying_key.verify_prehash(&message, &signature).is_ok())
+    }
+
+    fn check_locktime(&self, _locktime: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn check_sequence(&self, _sequence: i32) -> Result<bool, ChainGangError> {
+        Err(ChainGangError::IllegalState(
+            "Illegal transaction check".to_string(),
+        ))
+    }
+
+    fn tx_version(&self) -> Result<i32, ChainGangError> {
+        Ok(self.tx_version)
+    }
+}
+
 /// Checks that external values in a script are correct for a specific transaction spend
 pub struct TransactionChecker<'a> {
     /// Spending transaction

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -95,23 +95,11 @@ impl Checker for ZChecker {
 
         let sig_hash = self.z;
         let der_sig = &sig[0..sig.len() - 1];
-        let signature = match Signature::from_der(der_sig) {
-            Ok(sig) => sig,
-            Err(e) => {
-                println!("Failed to parse the signature: {e}");
-                return Err(e.into()); // Return the error to the caller
-            }
-        };
+        let signature = Signature::from_der(der_sig)?;
 
         let message = sig_hash.0;
 
-        let verifying_key = match VerifyingKey::from_sec1_bytes(pubkey) {
-            Ok(verkey) => verkey,
-            Err(e) => {
-                println!("Failed to parse the public key {e}");
-                return Err(e.into());
-            }
-        };
+        let verifying_key = VerifyingKey::from_sec1_bytes(pubkey)?;
 
         Ok(verifying_key.verify_prehash(&message, &signature).is_ok())
     }

--- a/src/script/format.rs
+++ b/src/script/format.rs
@@ -1,0 +1,311 @@
+use crate::script::op_codes::*;
+use crate::script::interpreter::next_op;
+use hex;
+
+/// How to render push-data and unknown opcodes when formatting a script.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ScriptFormatStyle {
+    /// Human-readable form used by `Script::string_representation`.
+    StringRep { include_byte_offsets: bool },
+    /// Compact form used by `Debug for Script`.
+    Debug,
+}
+
+/// Returns the canonical opcode name, if `byte` is a known opcode (not a direct push).
+pub fn opcode_name(byte: u8) -> Option<&'static str> {
+    match byte {
+        OP_0 => Some("OP_0"),
+        OP_1NEGATE => Some("OP_1NEGATE"),
+        OP_1 => Some("OP_1"),
+        OP_2 => Some("OP_2"),
+        OP_3 => Some("OP_3"),
+        OP_4 => Some("OP_4"),
+        OP_5 => Some("OP_5"),
+        OP_6 => Some("OP_6"),
+        OP_7 => Some("OP_7"),
+        OP_8 => Some("OP_8"),
+        OP_9 => Some("OP_9"),
+        OP_10 => Some("OP_10"),
+        OP_11 => Some("OP_11"),
+        OP_12 => Some("OP_12"),
+        OP_13 => Some("OP_13"),
+        OP_14 => Some("OP_14"),
+        OP_15 => Some("OP_15"),
+        OP_16 => Some("OP_16"),
+        OP_NOP => Some("OP_NOP"),
+        OP_VER => Some("OP_VER"),
+        OP_IF => Some("OP_IF"),
+        OP_NOTIF => Some("OP_NOTIF"),
+        OP_VERIF => Some("OP_VERIF"),
+        OP_VERNOTIF => Some("OP_VERNOTIF"),
+        OP_ELSE => Some("OP_ELSE"),
+        OP_ENDIF => Some("OP_ENDIF"),
+        OP_VERIFY => Some("OP_VERIFY"),
+        OP_RETURN => Some("OP_RETURN"),
+        OP_TOALTSTACK => Some("OP_TOALTSTACK"),
+        OP_FROMALTSTACK => Some("OP_FROMALTSTACK"),
+        OP_IFDUP => Some("OP_IFDUP"),
+        OP_DEPTH => Some("OP_DEPTH"),
+        OP_DROP => Some("OP_DROP"),
+        OP_DUP => Some("OP_DUP"),
+        OP_NIP => Some("OP_NIP"),
+        OP_OVER => Some("OP_OVER"),
+        OP_PICK => Some("OP_PICK"),
+        OP_ROLL => Some("OP_ROLL"),
+        OP_ROT => Some("OP_ROT"),
+        OP_SWAP => Some("OP_SWAP"),
+        OP_TUCK => Some("OP_TUCK"),
+        OP_2DROP => Some("OP_2DROP"),
+        OP_2DUP => Some("OP_2DUP"),
+        OP_3DUP => Some("OP_3DUP"),
+        OP_2OVER => Some("OP_2OVER"),
+        OP_2ROT => Some("OP_2ROT"),
+        OP_2SWAP => Some("OP_2SWAP"),
+        OP_CAT => Some("OP_CAT"),
+        OP_SPLIT => Some("OP_SPLIT"),
+        OP_SUBSTR => Some("OP_SUBSTR"),
+        OP_LEFT => Some("OP_LEFT"),
+        OP_RIGHT => Some("OP_RIGHT"),
+        OP_SIZE => Some("OP_SIZE"),
+        OP_AND => Some("OP_AND"),
+        OP_OR => Some("OP_OR"),
+        OP_XOR => Some("OP_XOR"),
+        OP_EQUAL => Some("OP_EQUAL"),
+        OP_EQUALVERIFY => Some("OP_EQUALVERIFY"),
+        OP_1ADD => Some("OP_1ADD"),
+        OP_1SUB => Some("OP_1SUB"),
+        OP_NEGATE => Some("OP_NEGATE"),
+        OP_ABS => Some("OP_ABS"),
+        OP_NOT => Some("OP_NOT"),
+        OP_0NOTEQUAL => Some("OP_0NOTEQUAL"),
+        OP_ADD => Some("OP_ADD"),
+        OP_SUB => Some("OP_SUB"),
+        OP_MUL => Some("OP_MUL"),
+        OP_2MUL => Some("OP_2MUL"),
+        OP_DIV => Some("OP_DIV"),
+        OP_2DIV => Some("OP_2DIV"),
+        OP_MOD => Some("OP_MOD"),
+        OP_LSHIFT => Some("OP_LSHIFT"),
+        OP_RSHIFT => Some("OP_RSHIFT"),
+        OP_LSHIFTNUM => Some("OP_LSHIFTNUM"),
+        OP_RSHIFTNUM => Some("OP_RSHIFTNUM"),
+        OP_BOOLAND => Some("OP_BOOLAND"),
+        OP_BOOLOR => Some("OP_BOOLOR"),
+        OP_NUMEQUAL => Some("OP_NUMEQUAL"),
+        OP_NUMEQUALVERIFY => Some("OP_NUMEQUALVERIFY"),
+        OP_NUMNOTEQUAL => Some("OP_NUMNOTEQUAL"),
+        OP_LESSTHAN => Some("OP_LESSTHAN"),
+        OP_GREATERTHAN => Some("OP_GREATERTHAN"),
+        OP_LESSTHANOREQUAL => Some("OP_LESSTHANOREQUAL"),
+        OP_GREATERTHANOREQUAL => Some("OP_GREATERTHANOREQUAL"),
+        OP_MIN => Some("OP_MIN"),
+        OP_MAX => Some("OP_MAX"),
+        OP_WITHIN => Some("OP_WITHIN"),
+        OP_NUM2BIN => Some("OP_NUM2BIN"),
+        OP_BIN2NUM => Some("OP_BIN2NUM"),
+        OP_RIPEMD160 => Some("OP_RIPEMD160"),
+        OP_SHA1 => Some("OP_SHA1"),
+        OP_SHA256 => Some("OP_SHA256"),
+        OP_HASH160 => Some("OP_HASH160"),
+        OP_HASH256 => Some("OP_HASH256"),
+        OP_CODESEPARATOR => Some("OP_CODESEPARATOR"),
+        OP_CHECKSIG => Some("OP_CHECKSIG"),
+        OP_CHECKSIGVERIFY => Some("OP_CHECKSIGVERIFY"),
+        OP_CHECKMULTISIG => Some("OP_CHECKMULTISIG"),
+        OP_CHECKMULTISIGVERIFY => Some("OP_CHECKMULTISIGVERIFY"),
+        OP_CHECKLOCKTIMEVERIFY => Some("OP_CHECKLOCKTIMEVERIFY"),
+        OP_CHECKSEQUENCEVERIFY => Some("OP_CHECKSEQUENCEVERIFY"),
+        _ => None,
+    }
+}
+
+fn append_direct_push(
+    out: &mut String,
+    script: &[u8],
+    i: usize,
+    len: u8,
+    style: ScriptFormatStyle,
+) -> bool {
+    let data_end = i + 1 + len as usize;
+    if data_end > script.len() {
+        return false;
+    }
+
+    match style {
+        ScriptFormatStyle::StringRep {
+            include_byte_offsets,
+        } => {
+            out.push_str("0x");
+            if include_byte_offsets {
+                out.push_str(&hex::encode(&script[i..data_end]));
+            } else {
+                out.push_str(&hex::encode(&script[i + 1..data_end]));
+            }
+        }
+        ScriptFormatStyle::Debug => {
+            out.push_str(&format!("OP_PUSH+{len} "));
+            out.push_str(&hex::encode(&script[i + 1..data_end]));
+        }
+    }
+    true
+}
+
+fn append_pushdata1(out: &mut String, script: &[u8], i: usize, style: ScriptFormatStyle) -> bool {
+    out.push_str("OP_PUSHDATA1 ");
+    if i + 2 > script.len() {
+        return false;
+    }
+    let len = script[i + 1] as usize;
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str(&format!("{len:#04x} ")),
+        ScriptFormatStyle::Debug => out.push_str(&format!("{len} ")),
+    }
+    if i + 2 + len > script.len() {
+        return false;
+    }
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str("0x"),
+        ScriptFormatStyle::Debug => {}
+    }
+    out.push_str(&hex::encode(&script[i + 2..i + 2 + len]));
+    true
+}
+
+fn append_pushdata2(out: &mut String, script: &[u8], i: usize, style: ScriptFormatStyle) -> bool {
+    out.push_str("OP_PUSHDATA2 ");
+    if i + 3 > script.len() {
+        return false;
+    }
+    let len = (script[i + 1] as usize) + ((script[i + 2] as usize) << 8);
+    match style {
+        ScriptFormatStyle::StringRep { .. } => {
+            out.push_str(&format!(
+                "{:#04x}{:02x} ",
+                script[i + 1] as usize,
+                script[i + 2] as usize
+            ));
+        }
+        ScriptFormatStyle::Debug => out.push_str(&format!("{len} ")),
+    }
+    if i + 3 + len > script.len() {
+        return false;
+    }
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str("0x"),
+        ScriptFormatStyle::Debug => {}
+    }
+    out.push_str(&hex::encode(&script[i + 3..i + 3 + len]));
+    true
+}
+
+fn append_pushdata4(out: &mut String, script: &[u8], i: usize, style: ScriptFormatStyle) -> bool {
+    out.push_str("OP_PUSHDATA4 ");
+    if i + 5 > script.len() {
+        return false;
+    }
+    let len = (script[i + 1] as usize)
+        + ((script[i + 2] as usize) << 8)
+        + ((script[i + 3] as usize) << 16)
+        + ((script[i + 4] as usize) << 24);
+    match style {
+        ScriptFormatStyle::StringRep { .. } => {
+            out.push_str(&format!(
+                "{:#04x}{:02x}{:02x}{:02x} ",
+                script[i + 1] as usize,
+                script[i + 2] as usize,
+                script[i + 3] as usize,
+                script[i + 4] as usize
+            ));
+        }
+        ScriptFormatStyle::Debug => out.push_str(&format!("{len} ")),
+    }
+    if i + 5 + len > script.len() {
+        return false;
+    }
+    match style {
+        ScriptFormatStyle::StringRep { .. } => out.push_str("0x"),
+        ScriptFormatStyle::Debug => {}
+    }
+    out.push_str(&hex::encode(&script[i + 5..i + 5 + len]));
+    true
+}
+
+fn append_script_op(
+    out: &mut String,
+    script: &[u8],
+    i: usize,
+    style: ScriptFormatStyle,
+) -> bool {
+    match script[i] {
+        len @ 1..=75 => append_direct_push(out, script, i, len, style),
+        OP_PUSHDATA1 => append_pushdata1(out, script, i, style),
+        OP_PUSHDATA2 => append_pushdata2(out, script, i, style),
+        OP_PUSHDATA4 => append_pushdata4(out, script, i, style),
+        byte => {
+            if let Some(name) = opcode_name(byte) {
+                out.push_str(name);
+            } else {
+                out.push_str(&byte.to_string());
+            }
+            true
+        }
+    }
+}
+
+pub(crate) fn format_script(script: &[u8], style: ScriptFormatStyle, prefix: &str, suffix: &str) -> String {
+    let mut ret = String::new();
+    ret.push_str(prefix);
+    let mut i = 0;
+
+    while i < script.len() {
+        if i != 0 {
+            ret.push(' ');
+        }
+        if !append_script_op(&mut ret, script, i, style) {
+            break;
+        }
+        i = next_op(i, script);
+    }
+
+    if i < script.len() {
+        for item in script.iter().skip(i) {
+            ret.push_str(&format!(" {item}"));
+        }
+    }
+
+    ret.push_str(suffix);
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::script::Script;
+
+    #[test]
+    fn opcode_name_covers_chronicle_opcodes() {
+        assert_eq!(opcode_name(OP_VER), Some("OP_VER"));
+        assert_eq!(opcode_name(OP_SUBSTR), Some("OP_SUBSTR"));
+        assert_eq!(opcode_name(OP_LSHIFTNUM), Some("OP_LSHIFTNUM"));
+    }
+
+    #[test]
+    fn format_script_matches_string_representation() {
+        let mut script = Script::new();
+        script.append_slice(&[OP_10, OP_5, OP_DIV]);
+        assert_eq!(
+            script.string_representation(false),
+            format_script(&script.0, ScriptFormatStyle::StringRep { include_byte_offsets: false }, "", "")
+        );
+    }
+
+    #[test]
+    fn format_script_matches_debug() {
+        let mut script = Script::new();
+        script.append_slice(&[OP_10, OP_5, OP_DIV]);
+        assert_eq!(
+            format!("{script:?}"),
+            format_script(&script.0, ScriptFormatStyle::Debug, "[", "]")
+        );
+    }
+}

--- a/src/script/interpreter.rs
+++ b/src/script/interpreter.rs
@@ -1,7 +1,9 @@
 use crate::script::op_codes::*;
 use crate::script::stack::{
-    decode_bigint, decode_bool, encode_bigint, encode_num, is_minimally_encoded, pop_bigint,
-    pop_bool, pop_bool_minimal, pop_num_minimal, Stack,
+    check_script_num_length, decode_bigint, decode_bool, encode_bigint, encode_num,
+    is_minimally_encoded, pop_bigint_checked, pop_bool, pop_bool_minimal, pop_num_minimal,
+    push_bigint_checked, Stack, MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,
+    MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
 };
 use crate::script::Checker;
 use crate::transaction::sighash::SIGHASH_FORKID;
@@ -29,6 +31,19 @@ pub fn uses_two_phase_eval(tx_version: u32) -> bool {
 /// Whether malleability-related script rules are relaxed (Chronicle).
 pub fn uses_relaxed_malleability(tx_version: u32) -> bool {
     tx_version > 1
+}
+
+/// Maximum encoded script number length for the current evaluation context.
+pub fn max_script_num_length<T: Checker>(checker: &T, flags: u32) -> usize {
+    if flags & PREGENESIS_RULES != 0 {
+        return MAX_SCRIPT_NUM_LENGTH_PREGENESIS;
+    }
+    if let Ok(version) = checker.tx_version() {
+        if version as u32 > 1 {
+            return MAX_SCRIPT_NUM_LENGTH_CHRONICLE;
+        }
+    }
+    MAX_SCRIPT_NUM_LENGTH_GENESIS
 }
 
 /// True when the script contains only push operations.
@@ -242,6 +257,7 @@ pub fn core_eval<T: Checker>(
     let mut branch_exec: Vec<bool> = Vec::new();
     let mut check_index = 0;
     let mut i = start_at.unwrap_or(0);
+    let max_num_len = max_script_num_length(checker, flags);
 
     'outer: while i < script.len() {
         if !branch_exec.is_empty() && !branch_exec[branch_exec.len() - 1] {
@@ -343,11 +359,11 @@ pub fn core_eval<T: Checker>(
             OP_IF => branch_exec.push(pop_bool_for_if(&mut stack, checker)?),
             OP_NOTIF => branch_exec.push(!pop_bool_for_if(&mut stack, checker)?),
             OP_VERIF => {
-                let comparison = pop_bigint(&mut stack)?;
+                let comparison = pop_bigint_checked(&mut stack, max_num_len)?;
                 branch_exec.push(verif_branch_exec(checker, comparison, false)?);
             }
             OP_VERNOTIF => {
-                let comparison = pop_bigint(&mut stack)?;
+                let comparison = pop_bigint_checked(&mut stack, max_num_len)?;
                 branch_exec.push(verif_branch_exec(checker, comparison, true)?);
             }
             OP_ELSE => {
@@ -668,99 +684,99 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_1ADD => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 x += 1;
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_1SUB => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 x -= 1;
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_NEGATE => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 x = -x;
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_ABS => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x < BigInt::zero() {
                     x = -x;
                 }
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_NOT => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x == BigInt::zero() {
                     x = BigInt::one();
                 } else {
                     x = BigInt::zero();
                 }
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_0NOTEQUAL => {
-                let mut x = pop_bigint(&mut stack)?;
+                let mut x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x == BigInt::zero() {
                     x = BigInt::zero();
                 } else {
                     x = BigInt::one();
                 }
-                stack.push(encode_bigint(x));
+                push_bigint_checked(&mut stack, x, max_num_len)?;
             }
             OP_ADD => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let sum = a + b;
-                stack.push(encode_bigint(sum));
+                push_bigint_checked(&mut stack, sum, max_num_len)?;
             }
             OP_SUB => {
-                let a = pop_bigint(&mut stack)?;
-                let b = pop_bigint(&mut stack)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
                 let difference = b - a;
-                stack.push(encode_bigint(difference));
+                push_bigint_checked(&mut stack, difference, max_num_len)?;
             }
             OP_MUL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let product = a * b;
-                stack.push(encode_bigint(product));
+                push_bigint_checked(&mut stack, product, max_num_len)?;
             }
             OP_2MUL => {
-                let a = pop_bigint(&mut stack)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let two = BigInt::from(2);
                 let product = a * two;
-                stack.push(encode_bigint(product));
+                push_bigint_checked(&mut stack, product, max_num_len)?;
             }
             OP_DIV => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if b == BigInt::zero() {
                     let msg = "OP_DIV failed, divide by 0".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
                 let quotient = a / b;
-                stack.push(encode_bigint(quotient));
+                push_bigint_checked(&mut stack, quotient, max_num_len)?;
             }
             OP_2DIV => {
-                let a = pop_bigint(&mut stack)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 let b = BigInt::from(2);
 
                 let quotient = a / b;
-                stack.push(encode_bigint(quotient));
+                push_bigint_checked(&mut stack, quotient, max_num_len)?;
             }
             OP_MOD => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if b == BigInt::zero() {
                     let msg = "OP_MOD failed, divide by 0".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
                 let remainder = a % b;
-                stack.push(encode_bigint(remainder));
+                push_bigint_checked(&mut stack, remainder, max_num_len)?;
             }
             OP_BOOLAND => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != BigInt::zero() && b != BigInt::zero() {
                     stack.push(encode_num(1)?);
                 } else {
@@ -768,8 +784,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_BOOLOR => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != BigInt::zero() || b != BigInt::zero() {
                     stack.push(encode_num(1)?);
                 } else {
@@ -777,8 +793,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_NUMEQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a == b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -786,16 +802,16 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_NUMEQUALVERIFY => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != b {
                     let msg = "Numbers are not equal".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
             }
             OP_NUMNOTEQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a != b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -803,8 +819,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_LESSTHAN => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a < b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -812,8 +828,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_GREATERTHAN => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a > b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -821,8 +837,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_LESSTHANOREQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a <= b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -830,8 +846,8 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_GREATERTHANOREQUAL => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a >= b {
                     stack.push(encode_num(1)?);
                 } else {
@@ -839,27 +855,27 @@ pub fn core_eval<T: Checker>(
                 }
             }
             OP_MIN => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a < b {
-                    stack.push(encode_bigint(a));
+                    push_bigint_checked(&mut stack, a, max_num_len)?;
                 } else {
-                    stack.push(encode_bigint(b));
+                    push_bigint_checked(&mut stack, b, max_num_len)?;
                 }
             }
             OP_MAX => {
-                let b = pop_bigint(&mut stack)?;
-                let a = pop_bigint(&mut stack)?;
+                let b = pop_bigint_checked(&mut stack, max_num_len)?;
+                let a = pop_bigint_checked(&mut stack, max_num_len)?;
                 if a > b {
-                    stack.push(encode_bigint(a));
+                    push_bigint_checked(&mut stack, a, max_num_len)?;
                 } else {
-                    stack.push(encode_bigint(b));
+                    push_bigint_checked(&mut stack, b, max_num_len)?;
                 }
             }
             OP_WITHIN => {
-                let max = pop_bigint(&mut stack)?;
-                let min = pop_bigint(&mut stack)?;
-                let x = pop_bigint(&mut stack)?;
+                let max = pop_bigint_checked(&mut stack, max_num_len)?;
+                let min = pop_bigint_checked(&mut stack, max_num_len)?;
+                let x = pop_bigint_checked(&mut stack, max_num_len)?;
                 if x >= min && x < max {
                     stack.push(encode_num(1)?);
                 } else {
@@ -868,7 +884,7 @@ pub fn core_eval<T: Checker>(
             }
             OP_NUM2BIN => {
                 check_stack_size(2, &stack)?;
-                let m = pop_bigint(&mut stack)?;
+                let m = pop_bigint_checked(&mut stack, max_num_len)?;
                 let mut n = stack.pop().unwrap();
                 if m < BigInt::one() {
                     let msg = format!("OP_NUM2BIN failed. m too small: {m}");
@@ -879,10 +895,11 @@ pub fn core_eval<T: Checker>(
                     let msg = "OP_NUM2BIN failed. n longer than m".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
-                if m > BigInt::from(2147483647) {
+                if m > BigInt::from(max_num_len) {
                     let msg = "OP_NUM2BIN failed. m too big".to_string();
                     return Err(ChainGangError::ScriptError(msg));
                 }
+                check_script_num_length(nlen, max_num_len)?;
                 let mut v = Vec::with_capacity(m.to_usize().unwrap());
                 let mut neg = 0;
                 if nlen > 0 {
@@ -898,13 +915,16 @@ pub fn core_eval<T: Checker>(
                 }
                 // Add the sign
                 v[0] |= neg;
+                check_script_num_length(v.len(), max_num_len)?;
                 stack.push(v);
             }
             OP_BIN2NUM => {
                 check_stack_size(1, &stack)?;
                 let mut v = stack.pop().unwrap();
+                check_script_num_length(v.len(), max_num_len)?;
                 let n = decode_bigint(&mut v);
                 let e = encode_bigint(n);
+                check_script_num_length(e.len(), max_num_len)?;
                 stack.push(e);
             }
             OP_RIPEMD160 => {
@@ -1288,6 +1308,10 @@ fn skip_branch(script: &[u8], mut i: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::script::stack::{
+        MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,
+        MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
+    };
     use crate::script::Script;
     use hex;
     use std::cell::RefCell;
@@ -2285,5 +2309,52 @@ mod tests {
     #[test]
     fn is_push_only_rejects_functional_opcodes() {
         assert!(!is_push_only(&[OP_2, OP_3, OP_ADD]));
+    }
+
+    #[test]
+    fn max_script_num_length_by_context() {
+        let c1 = MockChecker::with_tx_version(1);
+        assert_eq!(
+            max_script_num_length(&c1, NO_FLAGS),
+            MAX_SCRIPT_NUM_LENGTH_GENESIS
+        );
+        let c2 = MockChecker::with_tx_version(2);
+        assert_eq!(
+            max_script_num_length(&c2, NO_FLAGS),
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        );
+        let c3 = MockChecker::new();
+        assert_eq!(
+            max_script_num_length(&c3, NO_FLAGS),
+            MAX_SCRIPT_NUM_LENGTH_GENESIS
+        );
+        assert_eq!(
+            max_script_num_length(&c3, PREGENESIS_RULES),
+            MAX_SCRIPT_NUM_LENGTH_PREGENESIS
+        );
+    }
+
+    #[test]
+    fn genesis_script_num_limit_rejects_oversized_bin2num() {
+        let mut script = Script::new();
+        script.append(OP_PUSHDATA4);
+        script.append_slice(&(750_001_u32).to_le_bytes());
+        script.0.extend(std::iter::repeat_n(0u8, 750_001));
+        script.append(OP_BIN2NUM);
+        script.append(OP_1);
+        let mut c = MockChecker::with_tx_version(1);
+        assert!(eval(&script.0, &mut c, NO_FLAGS).is_err());
+    }
+
+    #[test]
+    fn chronicle_script_num_limit_accepts_genesis_max_bin2num() {
+        let mut script = Script::new();
+        script.append(OP_PUSHDATA4);
+        script.append_slice(&(750_000_u32).to_le_bytes());
+        script.0.extend(std::iter::repeat_n(0u8, 750_000));
+        script.append(OP_BIN2NUM);
+        script.append(OP_1);
+        let mut c = MockChecker::with_tx_version(2);
+        assert!(eval(&script.0, &mut c, NO_FLAGS).is_ok());
     }
 }

--- a/src/script/interpreter.rs
+++ b/src/script/interpreter.rs
@@ -1120,6 +1120,47 @@ pub fn eval_two_phase<T: Checker>(
     validate_final_stack(&stack, checker)
 }
 
+/// Like [`eval_two_phase`], but returns the final main and alt stacks after validation.
+pub fn eval_two_phase_with_stack<T: Checker>(
+    unlock: &[u8],
+    lock: &[u8],
+    checker: &mut T,
+    flags: u32,
+) -> Result<(Stack, Stack), ChainGangError> {
+    let ctx_unlock = TwoPhaseEvalContext {
+        lock_script: lock,
+        phase: TwoPhasePhase::Unlock,
+    };
+    let (stack, _, _) = core_eval(
+        unlock,
+        checker,
+        flags,
+        None,
+        None,
+        None,
+        None,
+        Some(&ctx_unlock),
+    )?;
+
+    let ctx_lock = TwoPhaseEvalContext {
+        lock_script: lock,
+        phase: TwoPhasePhase::Lock,
+    };
+    let (stack, alt_stack, _) = core_eval(
+        lock,
+        checker,
+        flags,
+        None,
+        None,
+        Some(stack),
+        None,
+        Some(&ctx_lock),
+    )?;
+
+    validate_final_stack(&stack, checker)?;
+    Ok((stack, alt_stack))
+}
+
 #[inline]
 fn check_multisig<T: Checker>(
     stack: &mut Stack,
@@ -2135,6 +2176,9 @@ mod tests {
         let lock = [OP_5, OP_EQUAL];
         let mut c = MockChecker::new();
         assert!(eval_two_phase(&unlock, &lock, &mut c, NO_FLAGS).is_ok());
+        let mut c2 = MockChecker::new();
+        let (stack, _) = eval_two_phase_with_stack(&unlock, &lock, &mut c2, NO_FLAGS).unwrap();
+        assert_eq!(stack.len(), 1);
     }
 
     #[test]

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -520,6 +520,7 @@ impl fmt::Debug for Script {
 mod tests {
     use super::op_codes::*;
     use super::*;
+    use crate::script::stack::encode_num;
 
     #[test]
     fn append_data() {
@@ -555,6 +556,24 @@ mod tests {
         s.append_data(&vec![0; 65536]);
         assert!(s.0[0] == OP_PUSHDATA4 && s.0[1] == 0 && s.0[2] == 0 && s.0[3] == 1);
         assert!(s.0.len() == 65541);
+    }
+
+    #[test]
+    fn eval_with_stack_start_at_skips_prefix() {
+        use crate::script::op_codes::*;
+        let script = [OP_1, OP_2, OP_3];
+        let (stack, _, _) = Script(script.to_vec())
+            .eval_with_stack(
+                &mut TransactionlessChecker {},
+                NO_FLAGS,
+                Some(2),
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack[0], encode_num(3).unwrap());
     }
 
     #[test]

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -27,11 +27,14 @@ mod interpreter;
 pub mod op_codes;
 pub mod stack;
 
-pub use self::checker::{Checker, TransactionChecker, TransactionlessChecker, ZChecker};
+pub use self::checker::{
+    Checker, TransactionChecker, TransactionlessChecker, TxVersionChecker, ZChecker,
+    ZVersionChecker,
+};
 pub(crate) use self::interpreter::next_op;
 pub use self::interpreter::{
-    eval_two_phase, is_push_only, max_script_num_length, uses_relaxed_malleability,
-    uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
+    eval_two_phase, eval_two_phase_with_stack, is_push_only, max_script_num_length,
+    uses_relaxed_malleability, uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
 };
 pub use self::stack::{
     check_script_num_length, MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -16,12 +16,11 @@
 //! script.eval(&mut TransactionlessChecker {}, NO_FLAGS).unwrap();
 //! ```
 
-use crate::script::op_codes::*;
 use crate::util::ChainGangError;
-use hex;
 use std::fmt;
 
 mod checker;
+mod format;
 mod interpreter;
 #[allow(dead_code)]
 pub mod op_codes;
@@ -41,6 +40,8 @@ pub use self::stack::{
     MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
 };
 pub use self::stack::Stack;
+
+use self::format::{format_script, ScriptFormatStyle};
 
 /// Transaction script
 #[derive(Default, Clone, PartialEq, Eq, Hash)]
@@ -130,392 +131,25 @@ impl Script {
 
     // Used by PyScript
     pub fn string_representation(&self, include_byte_offsets: bool) -> String {
-        let script = &self.0;
-        let mut ret = String::new();
-        let mut i = 0;
-
-        while i < script.len() {
-            if i != 0 {
-                ret.push(' ')
-            }
-            match script[i] {
-                OP_0 => ret.push_str("OP_0"),
-                OP_1NEGATE => ret.push_str("OP_1NEGATE"),
-                OP_1 => ret.push_str("OP_1"),
-                OP_2 => ret.push_str("OP_2"),
-                OP_3 => ret.push_str("OP_3"),
-                OP_4 => ret.push_str("OP_4"),
-                OP_5 => ret.push_str("OP_5"),
-                OP_6 => ret.push_str("OP_6"),
-                OP_7 => ret.push_str("OP_7"),
-                OP_8 => ret.push_str("OP_8"),
-                OP_9 => ret.push_str("OP_9"),
-                OP_10 => ret.push_str("OP_10"),
-                OP_11 => ret.push_str("OP_11"),
-                OP_12 => ret.push_str("OP_12"),
-                OP_13 => ret.push_str("OP_13"),
-                OP_14 => ret.push_str("OP_14"),
-                OP_15 => ret.push_str("OP_15"),
-                OP_16 => ret.push_str("OP_16"),
-                len @ 1..=75 => {
-                    if i + 1 + len as usize <= script.len() {
-                        ret.push_str("0x");
-
-                        if include_byte_offsets {
-                            // include the byte length of the data
-                            ret.push_str(&hex::encode(&script[i..i + 1 + len as usize]));
-                        } else {
-                            // exclude the byte length of the data
-                            ret.push_str(&hex::encode(&script[i + 1..i + 1 + len as usize]));
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA1 => {
-                    ret.push_str("OP_PUSHDATA1 ");
-                    if i + 2 <= script.len() {
-                        let len = script[i + 1] as usize;
-                        ret.push_str(&format!("{len:#04x} "));
-                        if i + 2 + len <= script.len() {
-                            ret.push_str("0x");
-                            ret.push_str(&hex::encode(&script[i + 2..i + 2 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA2 => {
-                    ret.push_str("OP_PUSHDATA2 ");
-                    if i + 3 <= script.len() {
-                        let len = (script[i + 1] as usize) + ((script[i + 2] as usize) << 8);
-                        //ret.push_str(&format!("{:#04x} ", (script[i + 1] as usize)));
-                        //ret.push_str(&format!("{:#04x} ", (script[i + 2] as usize)));
-
-                        ret.push_str(&format!(
-                            "{:#04x}{:02x} ",
-                            (script[i + 1] as usize),
-                            (script[i + 2] as usize)
-                        ));
-
-                        if i + 3 + len <= script.len() {
-                            ret.push_str("0x");
-                            ret.push_str(&hex::encode(&script[i + 3..i + 3 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA4 => {
-                    ret.push_str("OP_PUSHDATA4 ");
-                    if i + 5 <= script.len() {
-                        let len = (script[i + 1] as usize)
-                            + ((script[i + 2] as usize) << 8)
-                            + ((script[i + 3] as usize) << 16)
-                            + ((script[i + 4] as usize) << 24);
-
-                        ret.push_str(&format!(
-                            "{:#04x}{:02x}{:02x}{:02x} ",
-                            (script[i + 1] as usize),
-                            (script[i + 2] as usize),
-                            (script[i + 3] as usize),
-                            (script[i + 4] as usize)
-                        ));
-                        if i + 5 + len <= script.len() {
-                            ret.push_str("0x");
-                            ret.push_str(&hex::encode(&script[i + 5..i + 5 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_NOP => ret.push_str("OP_NOP"),
-                OP_VER => ret.push_str("OP_VER"),
-                OP_IF => ret.push_str("OP_IF"),
-                OP_NOTIF => ret.push_str("OP_NOTIF"),
-                OP_VERIF => ret.push_str("OP_VERIF"),
-                OP_VERNOTIF => ret.push_str("OP_VERNOTIF"),
-                OP_ELSE => ret.push_str("OP_ELSE"),
-                OP_ENDIF => ret.push_str("OP_ENDIF"),
-                OP_VERIFY => ret.push_str("OP_VERIFY"),
-                OP_RETURN => ret.push_str("OP_RETURN"),
-                OP_TOALTSTACK => ret.push_str("OP_TOALTSTACK"),
-                OP_FROMALTSTACK => ret.push_str("OP_FROMALTSTACK"),
-                OP_IFDUP => ret.push_str("OP_IFDUP"),
-                OP_DEPTH => ret.push_str("OP_DEPTH"),
-                OP_DROP => ret.push_str("OP_DROP"),
-                OP_DUP => ret.push_str("OP_DUP"),
-                OP_NIP => ret.push_str("OP_NIP"),
-                OP_OVER => ret.push_str("OP_OVER"),
-                OP_PICK => ret.push_str("OP_PICK"),
-                OP_ROLL => ret.push_str("OP_ROLL"),
-                OP_ROT => ret.push_str("OP_ROT"),
-                OP_SWAP => ret.push_str("OP_SWAP"),
-                OP_TUCK => ret.push_str("OP_TUCK"),
-                OP_2DROP => ret.push_str("OP_2DROP"),
-                OP_2DUP => ret.push_str("OP_2DUP"),
-                OP_3DUP => ret.push_str("OP_3DUP"),
-                OP_2OVER => ret.push_str("OP_2OVER"),
-                OP_2ROT => ret.push_str("OP_2ROT"),
-                OP_2SWAP => ret.push_str("OP_2SWAP"),
-                OP_CAT => ret.push_str("OP_CAT"),
-                OP_SPLIT => ret.push_str("OP_SPLIT"),
-                OP_SUBSTR => ret.push_str("OP_SUBSTR"),
-                OP_LEFT => ret.push_str("OP_LEFT"),
-                OP_RIGHT => ret.push_str("OP_RIGHT"),
-                OP_SIZE => ret.push_str("OP_SIZE"),
-                OP_AND => ret.push_str("OP_AND"),
-                OP_OR => ret.push_str("OP_OR"),
-                OP_XOR => ret.push_str("OP_XOR"),
-                OP_EQUAL => ret.push_str("OP_EQUAL"),
-                OP_EQUALVERIFY => ret.push_str("OP_EQUALVERIFY"),
-                OP_1ADD => ret.push_str("OP_1ADD"),
-                OP_1SUB => ret.push_str("OP_1SUB"),
-
-                OP_NEGATE => ret.push_str("OP_NEGATE"),
-                OP_ABS => ret.push_str("OP_ABS"),
-                OP_NOT => ret.push_str("OP_NOT"),
-                OP_0NOTEQUAL => ret.push_str("OP_0NOTEQUAL"),
-
-                OP_ADD => ret.push_str("OP_ADD"),
-                OP_SUB => ret.push_str("OP_SUB"),
-                OP_MUL => ret.push_str("OP_MUL"),
-                OP_2MUL => ret.push_str("OP_2MUL"),
-                OP_DIV => ret.push_str("OP_DIV"),
-                OP_2DIV => ret.push_str("OP_2DIV"),
-                OP_MOD => ret.push_str("OP_MOD"),
-                OP_LSHIFT => ret.push_str("OP_LSHIFT"),
-                OP_RSHIFT => ret.push_str("OP_RSHIFT"),
-                OP_LSHIFTNUM => ret.push_str("OP_LSHIFTNUM"),
-                OP_RSHIFTNUM => ret.push_str("OP_RSHIFTNUM"),
-
-                OP_BOOLAND => ret.push_str("OP_BOOLAND"),
-                OP_BOOLOR => ret.push_str("OP_BOOLOR"),
-                OP_NUMEQUAL => ret.push_str("OP_NUMEQUAL"),
-                OP_NUMEQUALVERIFY => ret.push_str("OP_NUMEQUALVERIFY"),
-                OP_NUMNOTEQUAL => ret.push_str("OP_NUMNOTEQUAL"),
-                OP_LESSTHAN => ret.push_str("OP_LESSTHAN"),
-                OP_GREATERTHAN => ret.push_str("OP_GREATERTHAN"),
-                OP_LESSTHANOREQUAL => ret.push_str("OP_LESSTHANOREQUAL"),
-                OP_GREATERTHANOREQUAL => ret.push_str("OP_GREATERTHANOREQUAL"),
-                OP_MIN => ret.push_str("OP_MIN"),
-                OP_MAX => ret.push_str("OP_MAX"),
-                OP_WITHIN => ret.push_str("OP_WITHIN"),
-                OP_NUM2BIN => ret.push_str("OP_NUM2BIN"),
-                OP_BIN2NUM => ret.push_str("OP_BIN2NUM"),
-                OP_RIPEMD160 => ret.push_str("OP_RIPEMD160"),
-                OP_SHA1 => ret.push_str("OP_SHA1"),
-                OP_SHA256 => ret.push_str("OP_SHA256"),
-                OP_HASH160 => ret.push_str("OP_HASH160"),
-                OP_HASH256 => ret.push_str("OP_HASH256"),
-                OP_CODESEPARATOR => ret.push_str("OP_CODESEPARATOR"),
-                OP_CHECKSIG => ret.push_str("OP_CHECKSIG"),
-                OP_CHECKSIGVERIFY => ret.push_str("OP_CHECKSIGVERIFY"),
-                OP_CHECKMULTISIG => ret.push_str("OP_CHECKMULTISIG"),
-                OP_CHECKMULTISIGVERIFY => ret.push_str("OP_CHECKMULTISIGVERIFY"),
-                OP_CHECKLOCKTIMEVERIFY => ret.push_str("OP_CHECKLOCKTIMEVERIFY"),
-                OP_CHECKSEQUENCEVERIFY => ret.push_str("OP_CHECKSEQUENCEVERIFY"),
-                _ => ret.push_str(&format!("{}", script[i])),
-            }
-            i = next_op(i, script);
-        }
-
-        // Add whatever is remaining if we exited early
-        if i < script.len() {
-            for item in script.iter().skip(i) {
-                ret.push_str(&format!(" {item}"));
-            }
-        }
-        ret
+        format_script(
+            &self.0,
+            ScriptFormatStyle::StringRep {
+                include_byte_offsets,
+            },
+            "",
+            "",
+        )
     }
 }
 
 impl fmt::Debug for Script {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let script = &self.0;
-        let mut ret = String::new();
-        let mut i = 0;
-        ret.push('[');
-        while i < script.len() {
-            if i != 0 {
-                ret.push(' ')
-            }
-            match script[i] {
-                OP_0 => ret.push_str("OP_0"),
-                OP_1NEGATE => ret.push_str("OP_1NEGATE"),
-                OP_1 => ret.push_str("OP_1"),
-                OP_2 => ret.push_str("OP_2"),
-                OP_3 => ret.push_str("OP_3"),
-                OP_4 => ret.push_str("OP_4"),
-                OP_5 => ret.push_str("OP_5"),
-                OP_6 => ret.push_str("OP_6"),
-                OP_7 => ret.push_str("OP_7"),
-                OP_8 => ret.push_str("OP_8"),
-                OP_9 => ret.push_str("OP_9"),
-                OP_10 => ret.push_str("OP_10"),
-                OP_11 => ret.push_str("OP_11"),
-                OP_12 => ret.push_str("OP_12"),
-                OP_13 => ret.push_str("OP_13"),
-                OP_14 => ret.push_str("OP_14"),
-                OP_15 => ret.push_str("OP_15"),
-                OP_16 => ret.push_str("OP_16"),
-                len @ 1..=75 => {
-                    ret.push_str(&format!("OP_PUSH+{len} "));
-                    if i + 1 + len as usize <= script.len() {
-                        ret.push_str(&hex::encode(&script[i + 1..i + 1 + len as usize]));
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA1 => {
-                    ret.push_str("OP_PUSHDATA1 ");
-                    if i + 2 <= script.len() {
-                        let len = script[i + 1] as usize;
-                        ret.push_str(&format!("{len} "));
-                        if i + 2 + len <= script.len() {
-                            ret.push_str(&hex::encode(&script[i + 2..i + 2 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA2 => {
-                    ret.push_str("OP_PUSHDATA2 ");
-                    if i + 3 <= script.len() {
-                        let len = (script[i + 1] as usize) + ((script[i + 2] as usize) << 8);
-                        ret.push_str(&format!("{len} "));
-                        if i + 3 + len <= script.len() {
-                            ret.push_str(&hex::encode(&script[i + 3..i + 3 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_PUSHDATA4 => {
-                    ret.push_str("OP_PUSHDATA4 ");
-                    if i + 5 <= script.len() {
-                        let len = (script[i + 1] as usize)
-                            + ((script[i + 2] as usize) << 8)
-                            + ((script[i + 3] as usize) << 16)
-                            + ((script[i + 4] as usize) << 24);
-                        ret.push_str(&format!("{len} "));
-                        if i + 5 + len <= script.len() {
-                            ret.push_str(&hex::encode(&script[i + 5..i + 5 + len]));
-                        } else {
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                OP_NOP => ret.push_str("OP_NOP"),
-                OP_VER => ret.push_str("OP_VER"),
-                OP_IF => ret.push_str("OP_IF"),
-                OP_NOTIF => ret.push_str("OP_NOTIF"),
-                OP_VERIF => ret.push_str("OP_VERIF"),
-                OP_VERNOTIF => ret.push_str("OP_VERNOTIF"),
-                OP_ELSE => ret.push_str("OP_ELSE"),
-                OP_ENDIF => ret.push_str("OP_ENDIF"),
-                OP_VERIFY => ret.push_str("OP_VERIFY"),
-                OP_RETURN => ret.push_str("OP_RETURN"),
-                OP_TOALTSTACK => ret.push_str("OP_TOALTSTACK"),
-                OP_FROMALTSTACK => ret.push_str("OP_FROMALTSTACK"),
-                OP_IFDUP => ret.push_str("OP_IFDUP"),
-                OP_DEPTH => ret.push_str("OP_DEPTH"),
-                OP_DROP => ret.push_str("OP_DROP"),
-                OP_DUP => ret.push_str("OP_DUP"),
-                OP_NIP => ret.push_str("OP_NIP"),
-                OP_OVER => ret.push_str("OP_OVER"),
-                OP_PICK => ret.push_str("OP_PICK"),
-                OP_ROLL => ret.push_str("OP_ROLL"),
-                OP_ROT => ret.push_str("OP_ROT"),
-                OP_SWAP => ret.push_str("OP_SWAP"),
-                OP_TUCK => ret.push_str("OP_TUCK"),
-                OP_2DROP => ret.push_str("OP_2DROP"),
-                OP_2DUP => ret.push_str("OP_2DUP"),
-                OP_3DUP => ret.push_str("OP_3DUP"),
-                OP_2OVER => ret.push_str("OP_2OVER"),
-                OP_2ROT => ret.push_str("OP_2ROT"),
-                OP_2SWAP => ret.push_str("OP_2SWAP"),
-                OP_CAT => ret.push_str("OP_CAT"),
-                OP_SPLIT => ret.push_str("OP_SPLIT"),
-                OP_SUBSTR => ret.push_str("OP_SUBSTR"),
-                OP_LEFT => ret.push_str("OP_LEFT"),
-                OP_RIGHT => ret.push_str("OP_RIGHT"),
-                OP_SIZE => ret.push_str("OP_SIZE"),
-                OP_AND => ret.push_str("OP_AND"),
-                OP_OR => ret.push_str("OP_OR"),
-                OP_XOR => ret.push_str("OP_XOR"),
-                OP_EQUAL => ret.push_str("OP_EQUAL"),
-                OP_EQUALVERIFY => ret.push_str("OP_EQUALVERIFY"),
-                OP_1ADD => ret.push_str("OP_1ADD"),
-                OP_1SUB => ret.push_str("OP_1SUB"),
-                OP_NEGATE => ret.push_str("OP_NEGATE"),
-                OP_ABS => ret.push_str("OP_ABS"),
-                OP_NOT => ret.push_str("OP_NOT"),
-                OP_0NOTEQUAL => ret.push_str("OP_0NOTEQUAL"),
-
-                OP_ADD => ret.push_str("OP_ADD"),
-                OP_SUB => ret.push_str("OP_SUB"),
-                OP_MUL => ret.push_str("OP_MUL"),
-                OP_2MUL => ret.push_str("OP_2MUL"),
-                OP_DIV => ret.push_str("OP_DIV"),
-                OP_2DIV => ret.push_str("OP_2DIV"),
-                OP_MOD => ret.push_str("OP_MOD"),
-                OP_LSHIFT => ret.push_str("OP_LSHIFT"),
-                OP_RSHIFT => ret.push_str("OP_RSHIFT"),
-                OP_LSHIFTNUM => ret.push_str("OP_LSHIFTNUM"),
-                OP_RSHIFTNUM => ret.push_str("OP_RSHIFTNUM"),
-
-                OP_BOOLAND => ret.push_str("OP_BOOLAND"),
-                OP_BOOLOR => ret.push_str("OP_BOOLOR"),
-                OP_NUMEQUAL => ret.push_str("OP_NUMEQUAL"),
-                OP_NUMEQUALVERIFY => ret.push_str("OP_NUMEQUALVERIFY"),
-                OP_NUMNOTEQUAL => ret.push_str("OP_NUMNOTEQUAL"),
-                OP_LESSTHAN => ret.push_str("OP_LESSTHAN"),
-                OP_GREATERTHAN => ret.push_str("OP_GREATERTHAN"),
-                OP_LESSTHANOREQUAL => ret.push_str("OP_LESSTHANOREQUAL"),
-                OP_GREATERTHANOREQUAL => ret.push_str("OP_GREATERTHANOREQUAL"),
-                OP_MIN => ret.push_str("OP_MIN"),
-                OP_MAX => ret.push_str("OP_MAX"),
-                OP_WITHIN => ret.push_str("OP_WITHIN"),
-                OP_NUM2BIN => ret.push_str("OP_NUM2BIN"),
-                OP_BIN2NUM => ret.push_str("OP_BIN2NUM"),
-                OP_RIPEMD160 => ret.push_str("OP_RIPEMD160"),
-                OP_SHA1 => ret.push_str("OP_SHA1"),
-                OP_SHA256 => ret.push_str("OP_SHA256"),
-                OP_HASH160 => ret.push_str("OP_HASH160"),
-                OP_HASH256 => ret.push_str("OP_HASH256"),
-                OP_CODESEPARATOR => ret.push_str("OP_CODESEPARATOR"),
-                OP_CHECKSIG => ret.push_str("OP_CHECKSIG"),
-                OP_CHECKSIGVERIFY => ret.push_str("OP_CHECKSIGVERIFY"),
-                OP_CHECKMULTISIG => ret.push_str("OP_CHECKMULTISIG"),
-                OP_CHECKMULTISIGVERIFY => ret.push_str("OP_CHECKMULTISIGVERIFY"),
-                OP_CHECKLOCKTIMEVERIFY => ret.push_str("OP_CHECKLOCKTIMEVERIFY"),
-                OP_CHECKSEQUENCEVERIFY => ret.push_str("OP_CHECKSEQUENCEVERIFY"),
-                _ => ret.push_str(&format!("{}", script[i])),
-            }
-            i = next_op(i, script);
-        }
-
-        // Add whatever is remaining if we exited early
-        if i < script.len() {
-            for item in script.iter().skip(i) {
-                ret.push_str(&format!(" {item}"));
-            }
-        }
-        ret.push(']');
-        f.write_str(&ret)
+        f.write_str(&format_script(
+            &self.0,
+            ScriptFormatStyle::Debug,
+            "[",
+            "]",
+        ))
     }
 }
 

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -30,8 +30,12 @@ pub mod stack;
 pub use self::checker::{Checker, TransactionChecker, TransactionlessChecker, ZChecker};
 pub(crate) use self::interpreter::next_op;
 pub use self::interpreter::{
-    eval_two_phase, is_push_only, uses_relaxed_malleability, uses_two_phase_eval, NO_FLAGS,
-    PREGENESIS_RULES,
+    eval_two_phase, is_push_only, max_script_num_length, uses_relaxed_malleability,
+    uses_two_phase_eval, NO_FLAGS, PREGENESIS_RULES,
+};
+pub use self::stack::{
+    check_script_num_length, MAX_SCRIPT_NUM_LENGTH_CHRONICLE, MAX_SCRIPT_NUM_LENGTH_GENESIS,
+    MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
 };
 pub use self::stack::Stack;
 

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -256,7 +256,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
     let len = s.len();
 
     if len == 0 {
-        println!("Zero length number");
         return Ok(BigInt::zero());
     }
 
@@ -278,7 +277,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
         if s[len - 1] & 128 != 0 {
             val = -val;
         }
-        println!("Returing this way");
         return Ok(BigInt::from(val));
     }
 
@@ -289,7 +287,6 @@ pub fn decode_number_combined(s: &[u8]) -> Result<BigInt, ChainGangError> {
     }
     let mut big_int_bytes = s.to_vec();
     big_int_bytes[len - 1] &= !0x80; // Clear the sign bit
-    println!("Returned this big num way");
     Ok(BigInt::from_bytes_le(sign, &big_int_bytes))
 }
 

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -5,6 +5,26 @@ use num_traits::Zero;
 // Type to simplify the types..
 pub type Stack = Vec<Vec<u8>>;
 
+/// Maximum script number size before Genesis (4 bytes).
+pub const MAX_SCRIPT_NUM_LENGTH_PREGENESIS: usize = 4;
+
+/// Maximum script number size after Genesis (750 KB).
+pub const MAX_SCRIPT_NUM_LENGTH_GENESIS: usize = 750_000;
+
+/// Maximum script number size after Chronicle (32 MB).
+pub const MAX_SCRIPT_NUM_LENGTH_CHRONICLE: usize = 32 * 1024 * 1024;
+
+/// Returns an error when a script number exceeds the allowed byte length.
+#[inline]
+pub fn check_script_num_length(len: usize, max_len: usize) -> Result<(), ChainGangError> {
+    if len > max_len {
+        return Err(ChainGangError::ScriptError(format!(
+            "Script number exceeds maximum length of {max_len}"
+        )));
+    }
+    Ok(())
+}
+
 /// Converts a stack item to a bool
 #[inline]
 pub fn decode_bool(s: &[u8]) -> bool {
@@ -107,6 +127,31 @@ pub fn pop_bigint(stack: &mut Stack) -> Result<BigInt, ChainGangError> {
     }
     let mut top = stack.pop().unwrap();
     Ok(decode_bigint(&mut top))
+}
+
+/// Pops a bigint number, enforcing a maximum encoded byte length.
+#[inline]
+pub fn pop_bigint_checked(stack: &mut Stack, max_len: usize) -> Result<BigInt, ChainGangError> {
+    if stack.is_empty() {
+        let msg = "Cannot pop bigint, empty stack".to_string();
+        return Err(ChainGangError::ScriptError(msg));
+    }
+    let mut top = stack.pop().unwrap();
+    check_script_num_length(top.len(), max_len)?;
+    Ok(decode_bigint(&mut top))
+}
+
+/// Pushes a bigint number, enforcing a maximum encoded byte length.
+#[inline]
+pub fn push_bigint_checked(
+    stack: &mut Stack,
+    val: BigInt,
+    max_len: usize,
+) -> Result<(), ChainGangError> {
+    let encoded = encode_bigint(val);
+    check_script_num_length(encoded.len(), max_len)?;
+    stack.push(encoded);
+    Ok(())
 }
 
 /// Converts a stack item to a number
@@ -318,6 +363,28 @@ mod tests {
     fn pop_num_minimal_rejects_non_minimal_encoding() {
         assert!(pop_num_minimal(&mut vec![vec![0, 0, 0, 0]], true).is_err());
         assert!(pop_num_minimal(&mut vec![vec![1]], true).unwrap() == 1);
+    }
+
+    #[test]
+    fn check_script_num_length_enforces_limit() {
+        assert!(check_script_num_length(750_000, MAX_SCRIPT_NUM_LENGTH_GENESIS).is_ok());
+        assert!(check_script_num_length(750_001, MAX_SCRIPT_NUM_LENGTH_GENESIS).is_err());
+        assert!(check_script_num_length(
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE,
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        )
+        .is_ok());
+        assert!(check_script_num_length(
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE + 1,
+            MAX_SCRIPT_NUM_LENGTH_CHRONICLE
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn push_bigint_checked_enforces_limit() {
+        let oversized = vec![1u8; MAX_SCRIPT_NUM_LENGTH_GENESIS + 1];
+        assert!(pop_bigint_checked(&mut vec![oversized], MAX_SCRIPT_NUM_LENGTH_GENESIS).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Merges the remaining Chronicle stack into `main` on top of #85–#89 (already merged):

- **Phase 6:** 32 MB script number limit (#90)
- **ROI cleanup:** Python eval breakpoint fix, debug prints, Cargo features, docs (#91)
- **Python parity:** `tx_version`, two-phase eval bindings, `Context` updates (#92)
- **Maintainability:** Shared script opcode formatting (#93)
- **Public API:** `chain_gang::chronicle` module (#94)
- **Activation:** `Tx::validate_at_height` + height helpers (#95)
- **Cleanup:** Remove `PyStack` debug println (#96)
- **Tests/docs:** `Tx.validate` integration tests, Python parity tests, library-vs-node docs (#97)

Chronicle script rules default to **`tx.version > 1`** in `Tx::validate()`; use `validate_at_height()` for BSV consensus activation heights.

## Test plan
- [x] `cargo test --all-features`
- [x] Python: `test_chronicle_context.py`, `test_chronicle_tx_validate.py`, `test_chronicle_opcodes.py`, `test_debug.py`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)