### PR TITLE
Add Python Tx.validate_at_height and high-S test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bitcoin SV [Chronicle](https://docs.bsvblockchain.org/network-topology/nodes/sv-
 
 Chronicle behavior is gated on **`tx.version > 1`** when using `Tx.validate()` (Python or Rust). Use `version: 2` (or higher) on spending transactions to opt in. For consensus-faithful activation at documented block heights, use Rust `Tx::validate_at_height()` — see [docs/Chronicle.md](docs/Chronicle.md#library-vs-node).
 
-**Python `Context` debugger:** pass optional `tx_version` and `lock_script` for Chronicle two-phase eval, relaxed clean stack, and `OP_VER`. `Context` does not enforce block-height activation; for full transaction checks use `Tx.validate()` (version-only) or Rust `validate_at_height()`.
+**Python `Context` debugger:** pass optional `tx_version` and `lock_script` for Chronicle two-phase eval, relaxed clean stack, and `OP_VER`. `Context` does not enforce block-height activation; for full transaction checks use `Tx.validate()` (version-only) or `Tx.validate_at_height()` with a BSV network name.
 
 # Python Installation
 As this library is hosted on PyPi (https://pypi.org/project/tx-engine/) and is installed using:

--- a/docs/Chronicle.md
+++ b/docs/Chronicle.md
@@ -30,7 +30,7 @@ This crate is a **transaction engine**, not a full BSV node. The distinction mat
 
 - Building or checking a Chronicle spend **before activation** or **without knowing the block**: use `validate()` and set `version > 1` to exercise Chronicle script rules intentionally.
 - Validating a transaction **as a node would at a known height** (e.g. block 943,835 on mainnet): use `validate_at_height(..., block_height, Network::BSV_Mainnet)`.
-- Python `Tx.validate()` calls the Rust `validate()` path (version-only). Use Rust bindings or add a height-aware Python wrapper if you need consensus-faithful height gating.
+- Python `Tx.validate()` calls the Rust `validate()` path (version-only). Use `Tx.validate_at_height(utxos, block_height, network)` for consensus-faithful height gating (`BSV_Mainnet`, `BSV_Testnet`, or `BSV_STN`).
 
 Sighash routing (`SIGHASH_CHRONICLE`) and signing policy (`uses_low_s_signing`) follow the signature flags independent of block height.
 

--- a/python/src/tests/test_chronicle_tx_validate.py
+++ b/python/src/tests/test_chronicle_tx_validate.py
@@ -2,12 +2,77 @@
 """
 import unittest
 
-from tx_engine import Context, Script, Tx, TxIn, TxOut
+from tx_engine import Context, Script, SIGHASH, Tx, TxIn, TxOut, Wallet
+from tx_engine.interface.verify_script import CHRONICLE_ACTIVATION_MAINNET
+
+SECP256K1_N = int(
+    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16
+)
 
 
 def display_tx_hash(tx: Tx) -> str:
     """Return the display-order txid hex string used by TxIn.prev_tx."""
     return bytes(reversed(bytes(tx.hash()))).hex()
+
+
+def _read_push(data: bytes, offset: int = 0) -> tuple[bytes, int]:
+    op = data[offset]
+    if 1 <= op <= 75:
+        length = op
+        start = offset + 1
+        return data[start:start + length], start + length
+    if op == 0x4C:
+        length = data[offset + 1]
+        start = offset + 2
+        return data[start:start + length], start + length
+    raise ValueError(f"unsupported push opcode 0x{op:02x}")
+
+
+def _push_bytes(data: bytes) -> bytes:
+    length = len(data)
+    if length <= 75:
+        return bytes([length]) + data
+    if length <= 255:
+        return bytes([0x4C, length]) + data
+    raise ValueError("push too large for test helper")
+
+
+def _der_split_rs(der: bytes) -> tuple[bytes, bytes]:
+    assert der[0] == 0x30
+    idx = 2
+    assert der[idx] == 0x02
+    r_len = der[idx + 1]
+    r = der[idx + 2:idx + 2 + r_len]
+    idx = idx + 2 + r_len
+    assert der[idx] == 0x02
+    s_len = der[idx + 1]
+    s = der[idx + 2:idx + 2 + s_len]
+    return r, s
+
+
+def _der_join(r: bytes, s: bytes) -> bytes:
+    body = b"\x02" + bytes([len(r)]) + r + b"\x02" + bytes([len(s)]) + s
+    return b"\x30" + bytes([len(body)]) + body
+
+
+def flip_der_to_high_s(der: bytes) -> bytes:
+    r, s_bytes = _der_split_rs(der)
+    s = int.from_bytes(s_bytes, "big")
+    if s > SECP256K1_N // 2:
+        raise ValueError("expected low-S DER input")
+    high_s = SECP256K1_N - s
+    s_enc = high_s.to_bytes((high_s.bit_length() + 7) // 8, "big")
+    if s_enc[0] & 0x80:
+        s_enc = b"\x00" + s_enc
+    return _der_join(r, s_enc)
+
+
+def replace_first_push_with_high_s(script: Script) -> Script:
+    sig_with_type, rest_offset = _read_push(bytes(script.cmds))
+    der, sighash_type = sig_with_type[:-1], sig_with_type[-1]
+    high_sig = flip_der_to_high_s(der) + bytes([sighash_type])
+    pubkey, _ = _read_push(bytes(script.cmds), rest_offset)
+    return Script(list(_push_bytes(high_sig)) + list(_push_bytes(pubkey)))
 
 
 class ChronicleTxValidateTest(unittest.TestCase):
@@ -78,6 +143,55 @@ class ChronicleTxValidateTest(unittest.TestCase):
         self.assertTrue(
             Context(script=unlock, lock_script=lock, tx_version=2).evaluate()
         )
+
+    def test_validate_at_height_rejects_pre_activation(self):
+        fund, spend = self._fund_and_spend(
+            Script.parse_string("OP_5 OP_EQUAL"),
+            Script.parse_string("OP_2 OP_3 OP_ADD"),
+            2,
+        )
+        self.assertIsNone(
+            spend.validate_at_height(
+                [fund],
+                CHRONICLE_ACTIVATION_MAINNET,
+                "BSV_Mainnet",
+            )
+        )
+        with self.assertRaises(ValueError):
+            spend.validate_at_height(
+                [fund],
+                CHRONICLE_ACTIVATION_MAINNET - 1,
+                "BSV_Mainnet",
+            )
+
+    def test_high_s_p2pkh_validates_for_chronicle_tx(self):
+        private_key = int.from_bytes(bytes([2] * 32), "big")
+        wallet = Wallet.from_int("BSV_Mainnet", private_key)
+
+        fund = Tx(
+            version=1,
+            tx_ins=[],
+            tx_outs=[TxOut(amount=10, script_pubkey=wallet.get_locking_script())],
+        )
+        spend = Tx(
+            version=2,
+            tx_ins=[
+                TxIn(
+                    display_tx_hash(fund),
+                    0,
+                    Script([]),
+                )
+            ],
+            tx_outs=[TxOut(amount=5, script_pubkey=Script([]))],
+        )
+        signed = wallet.sign_tx_sighash(
+            0, fund, spend, int(SIGHASH.ALL_FORKID_CHRONICLE)
+        )
+        high_s_unlock = replace_first_push_with_high_s(
+            signed.tx_ins[0].script_sig
+        )
+        signed.tx_ins[0].script_sig = high_s_unlock
+        self.assertIsNone(signed.validate([fund]))
 
 
 if __name__ == "__main__":

--- a/python/src/tx_engine/interface/verify_script.py
+++ b/python/src/tx_engine/interface/verify_script.py
@@ -3,8 +3,7 @@
 **Local validation (chain-gang):** ``Tx.validate()`` and ``Context`` do **not** use
 ``ScriptFlags``. Chronicle script rules (two-phase eval, malleability relaxation,
 32 MB script numbers, high-S verify) are gated on ``tx.version > 1``. Rust also
-supports height-aware checks via ``Tx::validate_at_height()``; Python ``Tx.validate()``
-uses version-only gating. See ``docs/Chronicle.md``.
+supports height-aware checks via ``Tx.validate_at_height()`` on Python and Rust.
 
 **Node RPC:** ``ScriptFlags`` documents flag bits for ``verifyscript`` calls through
 ``RPCInterface`` to a bitcoin-sv node. The node applies its own Chronicle activation

--- a/src/python/py_tx.rs
+++ b/src/python/py_tx.rs
@@ -1,5 +1,6 @@
 use crate::{
     messages::{OutPoint, Tx, TxIn, TxOut},
+    network::Network,
     python::py_script::PyScript,
     util::{ChainGangError, Hash256, Serializable},
 };
@@ -14,6 +15,53 @@ use std::{
     fmt,
     io::Cursor,
 };
+
+fn parse_network(network: &str) -> Result<Network, ChainGangError> {
+    match network {
+        "BSV_Mainnet" => Ok(Network::BSV_Mainnet),
+        "BSV_Testnet" => Ok(Network::BSV_Testnet),
+        "BSV_STN" => Ok(Network::BSV_STN),
+        _ => Err(ChainGangError::BadData(format!(
+            "Unknown network: {network}"
+        ))),
+    }
+}
+
+fn build_processed_utxos(
+    tx: &Tx,
+    utxos: &[PyTx],
+) -> Result<LinkedHashMap<OutPoint, TxOut>, ChainGangError> {
+    let outpoints: Vec<OutPoint> = tx.inputs.iter().map(|x| x.prev_output.clone()).collect();
+    let utxo_as_tx: HashMap<Hash256, Tx> = utxos
+        .iter()
+        .map(|x| x.as_tx())
+        .map(|tx| (tx.hash(), tx))
+        .collect();
+
+    let mut processed_utxo: LinkedHashMap<OutPoint, TxOut> = LinkedHashMap::new();
+    for op in outpoints {
+        match utxo_as_tx.get(&op.hash) {
+            Some(tx) => match tx.outputs.get(op.index as usize) {
+                Some(txout) => {
+                    processed_utxo.insert(op, txout.clone());
+                }
+                None => {
+                    return Err(ChainGangError::BadData(format!(
+                        "Invalid Outpoint index {}",
+                        op.index
+                    )));
+                }
+            },
+            None => {
+                return Err(ChainGangError::BadData(format!(
+                    "Unable to find hash {:?}",
+                    op.hash
+                )));
+            }
+        };
+    }
+    Ok(processed_utxo)
+}
 
 /// TxIn - This represents a bitcoin transaction input
 //
@@ -301,39 +349,39 @@ impl PyTx {
             return Err(ChainGangError::BadData(msg).into());
         }
 
-        // Get the tx input OutPoints
-        let outpoints: Vec<OutPoint> = tx.inputs.iter().map(|x| x.prev_output.clone()).collect();
-
-        // Speed up the OutPoint lookups by preparing HashMap
-        let utxo_as_tx: HashMap<Hash256, Tx> = utxos
-            .iter()
-            .map(|x| x.as_tx())
-            .map(|tx| (tx.hash(), tx))
-            .collect();
-
-        // Convert input utxos into processed_utxo: &LinkedHashMap<OutPoint, TxOut>,
-        let mut processed_utxo: LinkedHashMap<OutPoint, TxOut> = LinkedHashMap::new();
-        for op in outpoints {
-            match utxo_as_tx.get(&op.hash) {
-                Some(tx) => match tx.outputs.get(op.index as usize) {
-                    Some(txout) => processed_utxo.insert(op, txout.clone()),
-                    None => {
-                        let msg = format!("Invalid Outpoint index {}", op.index);
-                        return Err(ChainGangError::BadData(msg).into());
-                    }
-                },
-                None => {
-                    let msg = format!("Unable to find hash {:?}", op.hash);
-                    return Err(ChainGangError::BadData(msg).into());
-                }
-            };
-        }
-        // Empty HashSet
+        let processed_utxo = build_processed_utxos(&tx, &utxos)?;
         let pregenesis_outputs: HashSet<OutPoint> = HashSet::new();
+        Ok(tx.validate(true, true, &processed_utxo, &pregenesis_outputs)?)
+    }
 
-        // Call validate
-        let result = tx.validate(true, true, &processed_utxo, &pregenesis_outputs);
-        Ok(result?)
+    /// Validate with BSV Chronicle activation enforced at ``block_height`` on ``network``.
+    ///
+    /// ``network`` is one of ``BSV_Mainnet``, ``BSV_Testnet``, or ``BSV_STN``.
+    /// Unlike :meth:`validate`, this rejects ``tx.version > 1`` spends before the
+    /// documented Chronicle activation height on that network.
+    fn validate_at_height(
+        &self,
+        utxos: Vec<PyTx>,
+        block_height: u64,
+        network: &str,
+    ) -> PyResult<()> {
+        let tx = self.as_tx();
+        if tx.coinbase() {
+            let msg = "Validate can not check coinbase transactions.".to_string();
+            return Err(ChainGangError::BadData(msg).into());
+        }
+
+        let processed_utxo = build_processed_utxos(&tx, &utxos)?;
+        let pregenesis_outputs: HashSet<OutPoint> = HashSet::new();
+        let network = parse_network(network)?;
+        Ok(tx.validate_at_height(
+            true,
+            true,
+            &processed_utxo,
+            &pregenesis_outputs,
+            block_height,
+            network,
+        )?)
     }
 
     /// Parse Bytes to produce Tx


### PR DESCRIPTION
## Summary
- Adds `Tx.validate_at_height(utxos, block_height, network)` Python binding (mirrors Rust `Tx::validate_at_height`).
- Refactors UTXO map building in `py_tx.rs` shared by `validate()` and `validate_at_height()`.
- Extends `test_chronicle_tx_validate.py` with pre-activation height gating and high-S P2PKH Chronicle validation tests.
- Updates Chronicle docs/README to note Python height-aware validation.

## Test plan
- [x] `maturin develop --features python`
- [x] `python -m unittest test_chronicle_tx_validate.py -v` (7 tests)
- [x] `flake8` on modified Python files


Made with [Cursor](https://cursor.com)