### PR TITLE
Test Python 3.11–3.14 in CI

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -39,15 +39,19 @@ jobs:
         run: cargo test --all-features
 
   python-test:
-    name: Python Tests
+    name: Python Tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout branch code
         uses: actions/checkout@v4
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: Install Rust 
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,11 @@ description = "This library provides a Python interface for building BitcoinSV s
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
## Summary
- Runs push CI Python tests on **3.11, 3.12, 3.13, and 3.14** (matches `requires-python >= 3.11` and release wheels built with 3.14).
- Keeps Python lint/mypy on 3.12 only.
- Adds explicit PyPI classifiers for Python 3.11–3.14.

## Test plan
- [ ] CI matrix on this PR (4 Python versions × maturin build + `./tests.sh`)


Made with [Cursor](https://cursor.com)