### PR TITLE
Add BIP-39 seed bridge and Python HdWallet bindings

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -13,6 +13,7 @@ Class and function reference for **tx-engine**. For install and a quick start, s
 * [TxIn](#txin)
 * [TxOut](#txout)
 * [Wallet](#wallet)
+* [HdWallet](#hdwallet)
 * [Interface Factory](#interface-factory)
 * [Blockchain Interface](#blockchain-interface)
 * [Other Functions](#other-functions)
@@ -218,6 +219,47 @@ The library provides some additional helper functions to handle keys in differen
 
 
 ![Bitcoin Keys](diagrams/keys.png)
+
+
+## HdWallet
+
+BIP-32 hierarchical deterministic wallet. Derive child keys along a path, obtain P2PKH addresses (BIP-44 style), and get a leaf [`Wallet`](#wallet) for signing. Stacks on BIP-39 mnemonic support (`mnemonic_to_seed`).
+
+`HdWallet` class methods:
+
+* `HdWallet.from_seed(network: str, seed: bytes) -> HdWallet` - Master key from a 64-byte BIP-39 seed
+* `HdWallet.from_mnemonic(network: str, mnemonic: str, passphrase: str = "") -> HdWallet` - English BIP-39 mnemonic (validated) then seed derivation
+* `HdWallet.from_xprv(xprv: str) -> HdWallet` - Root from an encoded extended private key (`xprv...`)
+
+`HdWallet` methods:
+
+* `master_xprv() -> str` - Encoded master extended private key
+* `master_xpub() -> str` - Encoded master extended public key
+* `address_at(account: int, external: bool, index: int) -> str` - P2PKH address at `m/{account}'/{change}/{index}` (`external=True` → change 0)
+* `address_at_bip44(coin_type: int, account: int, external: bool, index: int) -> str` - P2PKH address at a full BIP-44 path
+* `wallet_at_path(path: str) -> Wallet` - Leaf signing wallet at the given path (e.g. `m/0'/0/0`)
+* `derive_xprv(path: str) -> str` - Extended private key at `path`
+* `derive_xpub(path: str) -> str` - Extended public key at `path`
+
+Path helpers (module functions):
+
+* `bip32_path(account: int, change: int, index: int) -> str` - `m/{account}'/{change}/{index}`
+* `bip44_path(coin_type: int, account: int, external: bool, index: int) -> str` - `m/44'/{coin_type}'/{account}'/{change}/{index}`
+* `bsv_coin_type() -> int` - BSV SLIP-44 coin type (`236`)
+* `mnemonic_to_seed(mnemonic: str, passphrase: str) -> bytes` - 64-byte BIP-39 seed (does not validate words)
+* `derive_extended_key(xprv: str, path: str) -> str` - Derive extended private key from master `xprv` and path
+
+Example:
+
+```Python
+from tx_engine import HdWallet, bip44_path, bsv_coin_type, mnemonic_to_seed
+
+mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic)
+addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
+wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
+signed_tx = wallet.sign_tx(0, prev_tx, tx)
+```
 
 
 ## Interface Factory

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -22,7 +22,7 @@ Features (all blockchains)
 BSV only Features
 * Transaction signing 
 * Script evaluation 
-* Wallet key derivation and mnemonic parsing
+* Wallet key derivation, BIP-32 HD wallets (`HdWallet`), and mnemonic parsing
 * Various Bitcoin primitives
 * Genesis upgrade support
 * [Chronicle upgrade](Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules)

--- a/python/src/tests/test_hd_wallet.py
+++ b/python/src/tests/test_hd_wallet.py
@@ -1,0 +1,41 @@
+""" HdWallet and BIP-32 Python binding tests
+"""
+import unittest
+
+from tx_engine import HdWallet, bip32_path, bip44_path, bsv_coin_type, derive_extended_key, mnemonic_to_seed
+
+
+ABANDON_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon about"
+)
+
+
+class HdWalletTest(unittest.TestCase):
+    """ HdWallet Python API
+    """
+
+    def test_mnemonic_to_seed_vector(self):
+        seed = mnemonic_to_seed(ABANDON_MNEMONIC, "")
+        self.assertEqual(len(seed), 64)
+
+    def test_hd_wallet_from_mnemonic_address(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
+        self.assertTrue(len(addr) > 20)
+
+    def test_wallet_at_path_signs(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        wallet = hd.wallet_at_path(bip32_path(0, 0, 0))
+        self.assertEqual(wallet.get_network(), "BSV_Mainnet")
+        self.assertTrue(wallet.get_address())
+
+    def test_derive_extended_key_matches_hd(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        path = bip44_path(bsv_coin_type(), 0, True, 1)
+        xprv = hd.derive_xprv(path)
+        self.assertEqual(derive_extended_key(hd.master_xprv(), path), xprv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -3,8 +3,8 @@ This is a tx_engine doc str
 """
 # noqa: F401 - 'x' - imported but unused
 
-from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce  # noqa: F401
+from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, HdWallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, mnemonic_to_seed, derive_extended_key, bip32_path, bip44_path, bsv_coin_type  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -5,6 +5,7 @@ mod op_code_names;
 mod py_script;
 mod py_stack;
 mod py_tx;
+mod py_hd_wallet;
 mod py_wallet;
 
 use crate::{
@@ -14,6 +15,10 @@ use crate::{
         py_script::PyScript,
         py_stack::{decode_num_stack, PyStack},
         py_tx::{PyTx, PyTxIn, PyTxOut},
+        py_hd_wallet::{
+            py_bip32_path, py_bip44_path, py_bsv_coin_type, py_derive_extended_key,
+            py_mnemonic_to_seed, PyHdWallet,
+        },
         py_wallet::{
             address_to_public_key_hash, bytes_to_wif, generate_wif, p2pkh_pyscript, wif_to_bytes,
             PyWallet,
@@ -470,8 +475,14 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTxIn>()?;
     m.add_class::<PyTxOut>()?;
     m.add_class::<PyTx>()?;
+    m.add_function(wrap_pyfunction!(py_mnemonic_to_seed, m)?)?;
+    m.add_function(wrap_pyfunction!(py_derive_extended_key, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bip32_path, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bip44_path, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bsv_coin_type, m)?)?;
     // Wallet class
     m.add_class::<PyWallet>()?;
+    m.add_class::<PyHdWallet>()?;
     // stack class
     m.add_class::<PyStack>()?;
     Ok(())

--- a/src/python/py_hd_wallet.rs
+++ b/src/python/py_hd_wallet.rs
@@ -1,0 +1,122 @@
+use crate::{
+    network::Network,
+    python::py_wallet::{str_to_network, PyWallet},
+    util::ChainGangError,
+    wallet::{
+        bip32_path, bip44_path, derive_extended_key, load_wordlist, mnemonic_to_seed, Wordlist,
+        BSV_COIN_TYPE, ExtendedKey, HdWallet,
+    },
+};
+
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+#[pyclass(name = "HdWallet")]
+pub struct PyHdWallet {
+    inner: HdWallet,
+}
+
+#[pymethods]
+impl PyHdWallet {
+  #[classmethod]
+  fn from_seed(_cls: &Bound<'_, PyType>, network: &str, seed: &[u8]) -> PyResult<Self> {
+    let net = parse_network(network)?;
+    Ok(PyHdWallet {
+      inner: HdWallet::from_seed(net, seed)?,
+    })
+  }
+
+  #[classmethod]
+  #[pyo3(signature = (network, mnemonic, passphrase=None))]
+  fn from_mnemonic(
+    _cls: &Bound<'_, PyType>,
+    network: &str,
+    mnemonic: &str,
+    passphrase: Option<&str>,
+  ) -> PyResult<Self> {
+    let net = parse_network(network)?;
+    let wordlist = load_wordlist(Wordlist::English);
+    let pass = passphrase.unwrap_or("");
+    Ok(PyHdWallet {
+      inner: HdWallet::from_mnemonic(net, mnemonic, pass, &wordlist)?,
+    })
+  }
+
+  #[classmethod]
+  fn from_xprv(_cls: &Bound<'_, PyType>, xprv: &str) -> PyResult<Self> {
+    let master = ExtendedKey::decode(xprv)?;
+    Ok(PyHdWallet {
+      inner: HdWallet::from_master(master)?,
+    })
+  }
+
+  fn master_xprv(&self) -> PyResult<String> {
+    Ok(self.inner.master().encode())
+  }
+
+  fn master_xpub(&self) -> PyResult<String> {
+    Ok(self.inner.master().extended_public_key()?.encode())
+  }
+
+  fn address_at(&self, account: u32, external: bool, index: u32) -> PyResult<String> {
+    Ok(self.inner.address_at(account, external, index)?)
+  }
+
+  fn address_at_bip44(
+    &self,
+    coin_type: u32,
+    account: u32,
+    external: bool,
+    index: u32,
+  ) -> PyResult<String> {
+    Ok(self.inner.address_at_bip44(coin_type, account, external, index)?)
+  }
+
+  fn wallet_at_path(&self, path: &str) -> PyResult<PyWallet> {
+    Ok(PyWallet::from_wallet(self.inner.wallet_at_path(path)?))
+  }
+
+  fn derive_xprv(&self, path: &str) -> PyResult<String> {
+    Ok(self.inner.derive_path(path)?.encode())
+  }
+
+  fn derive_xpub(&self, path: &str) -> PyResult<String> {
+    Ok(self
+      .inner
+      .derive_path(path)?
+      .extended_public_key()?
+      .encode())
+  }
+}
+
+fn parse_network(network: &str) -> PyResult<Network> {
+  str_to_network(network).ok_or_else(|| {
+    ChainGangError::BadArgument(format!("Unknown network {}", network)).into()
+  })
+}
+
+#[pyfunction(name = "mnemonic_to_seed")]
+pub fn py_mnemonic_to_seed(mnemonic: &str, passphrase: &str) -> Vec<u8> {
+  mnemonic_to_seed(mnemonic, passphrase).to_vec()
+}
+
+#[pyfunction(name = "derive_extended_key")]
+pub fn py_derive_extended_key(xprv: &str, path: &str) -> PyResult<String> {
+  let master = ExtendedKey::decode(xprv)?;
+  Ok(derive_extended_key(&master, path)?.encode())
+}
+
+#[pyfunction(name = "bip32_path")]
+pub fn py_bip32_path(account: u32, change: u32, index: u32) -> String {
+  bip32_path(account, change, index)
+}
+
+#[pyfunction(name = "bip44_path")]
+pub fn py_bip44_path(coin_type: u32, account: u32, external: bool, index: u32) -> String {
+  bip44_path(coin_type, account, external, index)
+}
+
+#[pyfunction(name = "bsv_coin_type")]
+pub fn py_bsv_coin_type() -> u32 {
+  BSV_COIN_TYPE
+}

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -152,6 +152,12 @@ pub struct PyWallet {
     wallet: Wallet,
 }
 
+impl PyWallet {
+    pub(crate) fn from_wallet(wallet: Wallet) -> Self {
+        PyWallet { wallet }
+    }
+}
+
 #[pymethods]
 impl PyWallet {
     // Given the wif_key, set up the wallet

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -6,6 +6,7 @@ use crate::util::ChainGangError;
 use crate::wallet::extended_key::{
     derive_extended_key, master_extended_key_from_seed, ExtendedKey, ExtendedKeyType,
 };
+use crate::wallet::mnemonic::mnemonic_to_seed_validated;
 use crate::wallet::wallet::Wallet;
 
 /// BSV mainnet coin type per SLIP-44.
@@ -45,6 +46,17 @@ impl HdWallet {
     pub fn from_seed(network: Network, seed: &[u8]) -> Result<Self, ChainGangError> {
         let master = master_extended_key_from_seed(network, seed)?;
         Ok(HdWallet { master })
+    }
+
+    /// Creates an HD wallet from a validated BIP-39 mnemonic (English word list).
+    pub fn from_mnemonic(
+        network: Network,
+        mnemonic: &str,
+        passphrase: &str,
+        word_list: &[String],
+    ) -> Result<Self, ChainGangError> {
+        let seed = mnemonic_to_seed_validated(mnemonic, passphrase, word_list)?;
+        Self::from_seed(network, &seed)
     }
 
     /// Master extended private key (`m`).
@@ -109,6 +121,17 @@ mod tests {
 
     fn test_seed() -> Vec<u8> {
         hex::decode("000102030405060708090a0b0c0d0e0f").unwrap()
+    }
+
+    #[test]
+    fn from_mnemonic_matches_from_seed() {
+        let wordlist = crate::wallet::load_wordlist(crate::wallet::Wordlist::English);
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let seed = crate::wallet::mnemonic_to_seed_validated(mnemonic, "", &wordlist).unwrap();
+        let from_seed = HdWallet::from_seed(Network::BSV_Mainnet, &seed).unwrap();
+        let from_mnemonic =
+            HdWallet::from_mnemonic(Network::BSV_Mainnet, mnemonic, "", &wordlist).unwrap();
+        assert_eq!(from_seed.master(), from_mnemonic.master());
     }
 
     #[test]

--- a/src/wallet/mnemonic.rs
+++ b/src/wallet/mnemonic.rs
@@ -1,9 +1,51 @@
 //! Functions to convert data to and from mnemonic words
 
 use crate::util::{Bits, ChainGangError};
-use sha2::{Digest, Sha256};
-
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use sha2::{Digest, Sha256, Sha512};
 use std::str;
+
+type HmacSha512 = Hmac<Sha512>;
+
+/// PBKDF2 iteration count for BIP-39 seed generation.
+pub const BIP39_PBKDF2_ITERATIONS: u32 = 2048;
+
+/// PBKDF2 salt prefix for BIP-39 (`mnemonic` + passphrase).
+pub const BIP39_SALT_PREFIX: &str = "mnemonic";
+
+/// Splits a mnemonic phrase into normalized words.
+pub fn mnemonic_parse(mnemonic: &str) -> Vec<String> {
+    mnemonic
+        .split_whitespace()
+        .map(|word| word.to_string())
+        .collect()
+}
+
+/// Derives a BIP-39 seed (64 bytes) from a mnemonic sentence and optional passphrase.
+pub fn mnemonic_to_seed(mnemonic: &str, passphrase: &str) -> [u8; 64] {
+    let salt = format!("{}{}", BIP39_SALT_PREFIX, passphrase);
+    let mut seed = [0u8; 64];
+    pbkdf2::<HmacSha512>(
+        mnemonic.as_bytes(),
+        salt.as_bytes(),
+        BIP39_PBKDF2_ITERATIONS,
+        &mut seed,
+    )
+    .expect("HMAC can take key of any size");
+    seed
+}
+
+/// Validates a mnemonic against a word list and returns the BIP-39 seed.
+pub fn mnemonic_to_seed_validated(
+    mnemonic: &str,
+    passphrase: &str,
+    word_list: &[String],
+) -> Result<[u8; 64], ChainGangError> {
+    let words = mnemonic_parse(mnemonic);
+    mnemonic_decode(&words, word_list)?;
+    Ok(mnemonic_to_seed(mnemonic, passphrase))
+}
 
 /// Wordlist language
 pub enum Wordlist {
@@ -87,6 +129,19 @@ pub fn mnemonic_decode(
 mod tests {
     use super::*;
     use hex;
+
+    #[test]
+    fn mnemonic_to_seed_vector() {
+        let wordlist = load_wordlist(Wordlist::English);
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        mnemonic_decode(&mnemonic_parse(mnemonic), &wordlist).unwrap();
+        let seed = mnemonic_to_seed(mnemonic, "");
+        let expected = hex::decode(
+            "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4",
+        )
+        .unwrap();
+        assert_eq!(seed.as_slice(), expected.as_slice());
+    }
 
     #[test]
     fn wordlists() {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -14,7 +14,10 @@ pub use self::extended_key::{
     MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY, TESTNET_PUBLIC_EXTENDED_KEY,
 };
 pub use self::hd_wallet::{bip32_path, bip44_path, BSV_COIN_TYPE, HdWallet};
-pub use self::mnemonic::{load_wordlist, mnemonic_decode, mnemonic_encode, Wordlist};
+pub use self::mnemonic::{
+    load_wordlist, mnemonic_decode, mnemonic_encode, mnemonic_parse, mnemonic_to_seed,
+    mnemonic_to_seed_validated, Wordlist, BIP39_PBKDF2_ITERATIONS, BIP39_SALT_PREFIX,
+};
 
 pub use self::wallet::{
     create_sighash, create_sighash_checksig_index, public_key_to_address, Wallet, MAIN_PRIVATE_KEY,


### PR DESCRIPTION
## Summary
- Add BIP-39 PBKDF2 seed helpers (`mnemonic_to_seed`, `mnemonic_to_seed_validated`) and `HdWallet::from_mnemonic`
- Expose `HdWallet`, path helpers, and `mnemonic_to_seed` through Python `tx_engine`
- Document HdWallet in `docs/Python-API.md`

Stacks on #107 (→ #106).

## Test plan
- [x] `cargo test mnemonic_to_seed`
- [x] `cargo test from_mnemonic`
- [x] `maturin develop --features python` + `unittest test_hd_wallet`


Made with [Cursor](https://cursor.com)