### PR TITLE
Add watch-only xpub wallet and BIP-32 gap scan

### DIFF
--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -14,6 +14,7 @@ Class and function reference for **tx-engine**. For install and a quick start, s
 * [TxOut](#txout)
 * [Wallet](#wallet)
 * [HdWallet](#hdwallet)
+* [HdWatchWallet](#hdwatchwallet)
 * [Interface Factory](#interface-factory)
 * [Blockchain Interface](#blockchain-interface)
 * [Other Functions](#other-functions)
@@ -260,6 +261,29 @@ addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
 wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
 signed_tx = wallet.sign_tx(0, prev_tx, tx)
 ```
+
+## HdWatchWallet
+
+Watch-only BIP-32 wallet from an account-level `xpub`. Use relative paths (`M/0/0`) for receive/change indices. Cannot sign transactions.
+
+`HdWatchWallet` class methods:
+
+* `HdWatchWallet.from_xpub(xpub: str) -> HdWatchWallet`
+
+`HdWatchWallet` methods:
+
+* `master_xpub() -> str`
+* `address_at(external: bool, index: int) -> str` — relative `M/{change}/{index}`
+* `address_at_bip44(external: bool, index: int) -> str`
+* `address_at_path(path: str) -> str`
+* `scan_addresses(external: bool, gap_limit: int, is_used: callable) -> List[str]` — gap-limit discovery; `is_used(address)` returns whether the address has been seen on-chain
+
+Path helpers for account-level `xpub`:
+
+* `watch_bip32_path(change: int, index: int) -> str`
+* `watch_bip44_path(external: bool, index: int) -> str`
+
+`HdWallet.scan_external_addresses(account, gap_limit, is_used)` scans receive addresses for a full HD wallet.
 
 
 ## Interface Factory

--- a/python/src/tests/test_hd_wallet.py
+++ b/python/src/tests/test_hd_wallet.py
@@ -2,7 +2,7 @@
 """
 import unittest
 
-from tx_engine import HdWallet, bip32_path, bip44_path, bsv_coin_type, derive_extended_key, mnemonic_to_seed
+from tx_engine import HdWallet, HdWatchWallet, bip32_path, bip44_path, bsv_coin_type, derive_extended_key, mnemonic_to_seed
 
 
 ABANDON_MNEMONIC = (
@@ -35,6 +35,15 @@ class HdWalletTest(unittest.TestCase):
         path = bip44_path(bsv_coin_type(), 0, True, 1)
         xprv = hd.derive_xprv(path)
         self.assertEqual(derive_extended_key(hd.master_xprv(), path), xprv)
+
+    def test_watch_wallet_from_account_xpub(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        account_xpub = hd.derive_xpub("m/0'")
+        watch = HdWatchWallet.from_xpub(account_xpub)
+        self.assertEqual(
+            watch.address_at(True, 0),
+            hd.address_at(0, True, 0),
+        )
 
 
 if __name__ == "__main__":

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -3,8 +3,8 @@ This is a tx_engine doc str
 """
 # noqa: F401 - 'x' - imported but unused
 
-from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, HdWallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, mnemonic_to_seed, derive_extended_key, bip32_path, bip44_path, bsv_coin_type  # noqa: F401
+from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, HdWallet, HdWatchWallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, mnemonic_to_seed, derive_extended_key, bip32_path, bip44_path, bsv_coin_type, watch_bip32_path, watch_bip44_path  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -17,7 +17,8 @@ use crate::{
         py_tx::{PyTx, PyTxIn, PyTxOut},
         py_hd_wallet::{
             py_bip32_path, py_bip44_path, py_bsv_coin_type, py_derive_extended_key,
-            py_mnemonic_to_seed, PyHdWallet,
+            py_mnemonic_to_seed, py_watch_bip32_path, py_watch_bip44_path, PyHdWallet,
+            PyHdWatchWallet,
         },
         py_wallet::{
             address_to_public_key_hash, bytes_to_wif, generate_wif, p2pkh_pyscript, wif_to_bytes,
@@ -480,9 +481,12 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_bip32_path, m)?)?;
     m.add_function(wrap_pyfunction!(py_bip44_path, m)?)?;
     m.add_function(wrap_pyfunction!(py_bsv_coin_type, m)?)?;
+    m.add_function(wrap_pyfunction!(py_watch_bip32_path, m)?)?;
+    m.add_function(wrap_pyfunction!(py_watch_bip44_path, m)?)?;
     // Wallet class
     m.add_class::<PyWallet>()?;
     m.add_class::<PyHdWallet>()?;
+    m.add_class::<PyHdWatchWallet>()?;
     // stack class
     m.add_class::<PyStack>()?;
     Ok(())

--- a/src/python/py_hd_wallet.rs
+++ b/src/python/py_hd_wallet.rs
@@ -3,8 +3,8 @@ use crate::{
     python::py_wallet::{str_to_network, PyWallet},
     util::ChainGangError,
     wallet::{
-        bip32_path, bip44_path, derive_extended_key, load_wordlist, mnemonic_to_seed, Wordlist,
-        BSV_COIN_TYPE, ExtendedKey, HdWallet,
+        bip32_path, bip44_path, derive_extended_key, load_wordlist, mnemonic_to_seed, watch_bip32_path,
+        watch_bip44_path, Wordlist, BSV_COIN_TYPE, ExtendedKey, HdWallet, HdWatchWallet,
     },
 };
 
@@ -87,6 +87,66 @@ impl PyHdWallet {
       .extended_public_key()?
       .encode())
   }
+
+  fn scan_external_addresses(
+    &self,
+    account: u32,
+    gap_limit: u32,
+    is_used: &Bound<'_, PyAny>,
+  ) -> PyResult<Vec<String>> {
+    Ok(self
+      .inner
+      .scan_external_addresses(account, gap_limit, |addr| call_is_used(is_used, addr))?)
+  }
+}
+
+#[pyclass(name = "HdWatchWallet")]
+pub struct PyHdWatchWallet {
+  inner: HdWatchWallet,
+}
+
+#[pymethods]
+impl PyHdWatchWallet {
+  #[classmethod]
+  fn from_xpub(_cls: &Bound<'_, PyType>, xpub: &str) -> PyResult<Self> {
+    Ok(PyHdWatchWallet {
+      inner: HdWatchWallet::from_xpub(xpub)?,
+    })
+  }
+
+  fn master_xpub(&self) -> PyResult<String> {
+    Ok(self.inner.master().encode())
+  }
+
+  fn address_at(&self, external: bool, index: u32) -> PyResult<String> {
+    Ok(self.inner.address_at(external, index)?)
+  }
+
+  fn address_at_bip44(&self, external: bool, index: u32) -> PyResult<String> {
+    Ok(self.inner.address_at_bip44(external, index)?)
+  }
+
+  fn address_at_path(&self, path: &str) -> PyResult<String> {
+    Ok(self.inner.address_at_path(path)?)
+  }
+
+  fn scan_addresses(
+    &self,
+    external: bool,
+    gap_limit: u32,
+    is_used: &Bound<'_, PyAny>,
+  ) -> PyResult<Vec<String>> {
+    Ok(self
+      .inner
+      .scan_addresses(external, gap_limit, |addr| call_is_used(is_used, addr))?)
+  }
+}
+
+fn call_is_used(is_used: &Bound<'_, PyAny>, addr: &str) -> bool {
+  is_used
+    .call1((addr,))
+    .and_then(|v| v.extract::<bool>())
+    .unwrap_or(false)
 }
 
 fn parse_network(network: &str) -> PyResult<Network> {
@@ -119,4 +179,14 @@ pub fn py_bip44_path(coin_type: u32, account: u32, external: bool, index: u32) -
 #[pyfunction(name = "bsv_coin_type")]
 pub fn py_bsv_coin_type() -> u32 {
   BSV_COIN_TYPE
+}
+
+#[pyfunction(name = "watch_bip32_path")]
+pub fn py_watch_bip32_path(change: u32, index: u32) -> String {
+  watch_bip32_path(change, index)
+}
+
+#[pyfunction(name = "watch_bip44_path")]
+pub fn py_watch_bip44_path(external: bool, index: u32) -> String {
+  watch_bip44_path(external, index)
 }

--- a/src/wallet/extended_key.rs
+++ b/src/wallet/extended_key.rs
@@ -21,6 +21,9 @@ const SECP256K1_CURVE_ORDER: [u8; 32] = [
 /// Index which begins the derived hardened keys
 pub const HARDENED_KEY: u32 = 2147483648;
 
+/// Error message when BIP-32 child derivation must skip to the next index.
+pub const INVALID_CHILD_KEY_MSG: &str = "Invalid key. Try next index.";
+
 /// "xpub" prefix for public extended keys on mainnet
 pub const MAINNET_PUBLIC_EXTENDED_KEY: u32 = 0x0488B21E;
 /// "xprv" prefix for private extended keys on mainnet
@@ -259,8 +262,28 @@ impl ExtendedKey {
         }
     }
 
-    /// Derives an extended child private key from an extended parent private key
+    /// Derives an extended child private key from an extended parent private key.
+    ///
+    /// If the derived key is invalid per BIP-32, increments the child index and retries.
     pub fn derive_private_key(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
+        let mut idx = index;
+        loop {
+            match self.try_derive_private_key_once(idx) {
+                Ok(key) => return Ok(key),
+                Err(ChainGangError::IllegalState(ref msg)) if msg == INVALID_CHILD_KEY_MSG => {
+                    if idx == u32::MAX {
+                        return Err(ChainGangError::BadData(
+                            "No valid BIP-32 child private key found".to_string(),
+                        ));
+                    }
+                    idx += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn try_derive_private_key_once(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
         if self.key_type()? == ExtendedKeyType::Public {
             let msg = "Cannot derive private key from public key";
             return Err(ChainGangError::BadData(msg.to_string()));
@@ -303,19 +326,13 @@ impl ExtendedKey {
         }
 
         if !is_private_key_valid(&hmac[..32]) {
-            let msg = "Invalid key. Try next index.".to_string();
-            return Err(ChainGangError::IllegalState(msg));
+            return Err(ChainGangError::IllegalState(INVALID_CHILD_KEY_MSG.to_string()));
         }
 
         let secp_child_secret_key = SecretKey::from_slice(&hmac[..32])?;
         let child_sk = *secp_child_secret_key.as_scalar_primitive();
         let private_sk = secp_par_secret_key.as_scalar_primitive();
-
-        //secp_child_secret_key.add_assign(private_key)?;
         let child_sk = child_sk.add(private_sk);
-
-        //let child_private_key =
-        //    unsafe { slice::from_raw_parts(secp_child_secret_key.as_ptr(), 32) };
         let child_private_key: [u8; 32] = child_sk.to_bytes().into();
 
         let child_chain_code = &hmac[32..];
@@ -331,8 +348,28 @@ impl ExtendedKey {
         )
     }
 
-    /// Derives an extended child public key from an extended parent public key
+    /// Derives an extended child public key from an extended parent public key.
+    ///
+    /// If the derived key is invalid per BIP-32, increments the child index and retries.
     pub fn derive_public_key(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
+        let mut idx = index;
+        loop {
+            match self.try_derive_public_key_once(idx) {
+                Ok(key) => return Ok(key),
+                Err(ChainGangError::IllegalState(ref msg)) if msg == INVALID_CHILD_KEY_MSG => {
+                    if idx == u32::MAX {
+                        return Err(ChainGangError::BadData(
+                            "No valid BIP-32 child public key found".to_string(),
+                        ));
+                    }
+                    idx += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn try_derive_public_key_once(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
         if index >= HARDENED_KEY {
             return Err(ChainGangError::BadArgument(
                 "i cannot be hardened".to_string(),
@@ -361,8 +398,7 @@ impl ExtendedKey {
         }
 
         if !is_private_key_valid(&hmac[..32]) {
-            let msg = "Invalid key. Try next index.".to_string();
-            return Err(ChainGangError::IllegalState(msg));
+            return Err(ChainGangError::IllegalState(INVALID_CHILD_KEY_MSG.to_string()));
         }
 
         let secret_key = SecretKey::from_slice(&hmac[..32])?;
@@ -371,8 +407,9 @@ impl ExtendedKey {
             .map_err(|_| ChainGangError::BadData("Invalid parent public key".to_string()))?;
         let offset_pk = secret_key.public_key();
         let child_point = parent_pk.to_projective() + offset_pk.to_projective();
-        let child_pk = PublicKey::<Secp256k1>::try_from(child_point)
-            .map_err(|_| ChainGangError::BadData("Invalid derived public key".to_string()))?;
+        let child_pk = PublicKey::<Secp256k1>::try_from(child_point).map_err(|_| {
+            ChainGangError::IllegalState(INVALID_CHILD_KEY_MSG.to_string())
+        })?;
         let child_bytes = child_pk.to_sec1_bytes();
         let pk_vec = child_bytes.to_vec();
         assert!(pk_vec.len() == 33);

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -108,6 +108,23 @@ impl HdWallet {
     ) -> Result<String, ChainGangError> {
         self.wallet_at_path(&bip44_path(coin_type, account, external, index))?.get_address()
     }
+
+    /// Scans external receive addresses for `account` until `gap_limit` consecutive unused indices.
+    pub fn scan_external_addresses<F>(
+        &self,
+        account: u32,
+        gap_limit: u32,
+        is_used: F,
+    ) -> Result<Vec<String>, ChainGangError>
+    where
+        F: Fn(&str) -> bool,
+    {
+        crate::wallet::hd_watch_wallet::scan_address_indices(
+            |i| self.address_at(account, true, i),
+            gap_limit,
+            is_used,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/wallet/hd_watch_wallet.rs
+++ b/src/wallet/hd_watch_wallet.rs
@@ -1,0 +1,191 @@
+//! BIP-32 watch-only (xpub) wallet helpers.
+
+use crate::network::Network;
+use crate::script::Script;
+use crate::util::ChainGangError;
+use crate::wallet::extended_key::{
+    derive_extended_key, ExtendedKey, ExtendedKeyType,
+};
+use crate::wallet::wallet::{p2pkh_script, public_key_to_address};
+
+/// Default BIP-44 gap limit for address discovery.
+pub const DEFAULT_GAP_LIMIT: u32 = 20;
+
+/// Builds a relative BIP-32 path from an account-level extended public key: `M/{change}/{index}`.
+pub fn watch_bip32_path(change: u32, index: u32) -> String {
+    format!("M/{}/{}", change, index)
+}
+
+/// Builds a relative BIP-44 path from an account-level extended public key.
+pub fn watch_bip44_path(external: bool, index: u32) -> String {
+    let change = if external { 0 } else { 1 };
+    watch_bip32_path(change, index)
+}
+
+/// Watch-only HD wallet rooted at an extended **public** key (typically account-level `xpub`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HdWatchWallet {
+    master: ExtendedKey,
+}
+
+impl HdWatchWallet {
+    /// Creates a watch-only wallet from an encoded extended public key (`xpub` / `tpub`).
+    pub fn from_xpub(xpub: &str) -> Result<Self, ChainGangError> {
+        Self::from_master(ExtendedKey::decode(xpub)?)
+    }
+
+    /// Creates a watch-only wallet from a master extended public key.
+    pub fn from_master(master: ExtendedKey) -> Result<Self, ChainGangError> {
+        if master.key_type()? != ExtendedKeyType::Public {
+            return Err(ChainGangError::BadArgument(
+                "HdWatchWallet requires an extended public key".to_string(),
+            ));
+        }
+        Ok(HdWatchWallet { master })
+    }
+
+    pub fn master(&self) -> ExtendedKey {
+        self.master
+    }
+
+    pub fn network(&self) -> Result<Network, ChainGangError> {
+        self.master.network()
+    }
+
+    /// Derives an extended public key along a BIP-32 path (`M/...`).
+    pub fn derive_path(&self, path: &str) -> Result<ExtendedKey, ChainGangError> {
+        derive_extended_key(&self.master, path)
+    }
+
+    /// Compressed public key bytes at `path`.
+    pub fn public_key_at_path(&self, path: &str) -> Result<Vec<u8>, ChainGangError> {
+        Ok(self.derive_path(path)?.public_key()?.to_vec())
+    }
+
+    /// P2PKH address at `path`.
+    pub fn address_at_path(&self, path: &str) -> Result<String, ChainGangError> {
+        let pk = self.public_key_at_path(path)?;
+        public_key_to_address(&pk, self.network()?)
+    }
+
+    /// P2PKH locking script at `path`.
+    pub fn locking_script_at_path(&self, path: &str) -> Result<Script, ChainGangError> {
+        let pk = self.public_key_at_path(path)?;
+        Ok(p2pkh_script(&crate::util::hash160(&pk).0))
+    }
+
+    /// P2PKH address at `M/{change}/{index}` relative to an account-level `xpub`.
+    pub fn address_at(&self, external: bool, index: u32) -> Result<String, ChainGangError> {
+        let change = if external { 0 } else { 1 };
+        self.address_at_path(&watch_bip32_path(change, index))
+    }
+
+    /// P2PKH address at a relative BIP-44 receive/change chain index.
+    pub fn address_at_bip44(&self, external: bool, index: u32) -> Result<String, ChainGangError> {
+        self.address_at_path(&watch_bip44_path(external, index))
+    }
+
+    /// Scans external or change chain indices until `gap_limit` consecutive unused addresses.
+    pub fn scan_addresses<F>(
+        &self,
+        external: bool,
+        gap_limit: u32,
+        is_used: F,
+    ) -> Result<Vec<String>, ChainGangError>
+    where
+        F: Fn(&str) -> bool,
+    {
+        scan_address_indices(|i| self.address_at(external, i), gap_limit, is_used)
+    }
+}
+
+/// Scans address indices until `gap_limit` consecutive unused addresses.
+pub fn scan_address_indices<G, H>(
+    address_at: G,
+    gap_limit: u32,
+    is_used: H,
+) -> Result<Vec<String>, ChainGangError>
+where
+    G: Fn(u32) -> Result<String, ChainGangError>,
+    H: Fn(&str) -> bool,
+{
+    let mut used_addresses = Vec::new();
+    let mut gap = 0u32;
+    let mut index = 0u32;
+
+    while gap < gap_limit {
+        let addr = address_at(index)?;
+        if is_used(&addr) {
+            used_addresses.push(addr);
+            gap = 0;
+        } else {
+            gap += 1;
+        }
+        index += 1;
+    }
+
+    Ok(used_addresses)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::hd_wallet::{bip32_path, HdWallet};
+    use hex;
+
+    fn test_seed() -> Vec<u8> {
+        hex::decode("000102030405060708090a0b0c0d0e0f").unwrap()
+    }
+
+    #[test]
+    fn watch_wallet_matches_private_derivation() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let account_xpub = hd
+            .derive_path("m/0'")
+            .unwrap()
+            .extended_public_key()
+            .unwrap()
+            .encode();
+        let watch = HdWatchWallet::from_xpub(&account_xpub).unwrap();
+
+        let priv_addr = hd.address_at(0, true, 5).unwrap();
+        let watch_addr = watch.address_at(true, 5).unwrap();
+        assert_eq!(priv_addr, watch_addr);
+    }
+
+    #[test]
+    fn watch_path_matches_full_bip32_path() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let account_xpub = hd
+            .derive_path("m/0'")
+            .unwrap()
+            .extended_public_key()
+            .unwrap()
+            .encode();
+        let watch = HdWatchWallet::from_xpub(&account_xpub).unwrap();
+
+        let path = bip32_path(0, 0, 3);
+        let full_addr = hd.wallet_at_path(&path).unwrap().get_address().unwrap();
+        let watch_addr = watch.address_at_path(&watch_bip32_path(0, 3)).unwrap();
+        assert_eq!(full_addr, watch_addr);
+    }
+
+    #[test]
+    fn gap_scan_collects_used_addresses() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let account_xpub = hd
+            .derive_path("m/0'")
+            .unwrap()
+            .extended_public_key()
+            .unwrap()
+            .encode();
+        let watch = HdWatchWallet::from_xpub(&account_xpub).unwrap();
+
+        let a0 = watch.address_at(true, 0).unwrap();
+        let a2 = watch.address_at(true, 2).unwrap();
+        let used = watch
+            .scan_addresses(true, 2, |addr| addr == &a0 || addr == &a2)
+            .unwrap();
+        assert_eq!(used, vec![a0, a2]);
+    }
+}

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2,6 +2,7 @@
 
 mod extended_key;
 mod hd_wallet;
+mod hd_watch_wallet;
 mod mnemonic;
 
 pub mod base58_checksum;
@@ -10,10 +11,14 @@ pub mod wallet;
 
 pub use self::extended_key::{
     derive_extended_key, master_extended_key_from_seed, ExtendedKey, ExtendedKeyType,
-    BIP32_MASTER_SEED_KEY, HARDENED_KEY, MIN_BIP32_SEED_LENGTH, MAINNET_PRIVATE_EXTENDED_KEY,
-    MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY, TESTNET_PUBLIC_EXTENDED_KEY,
+    BIP32_MASTER_SEED_KEY, HARDENED_KEY, INVALID_CHILD_KEY_MSG, MIN_BIP32_SEED_LENGTH,
+    MAINNET_PRIVATE_EXTENDED_KEY, MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY,
+    TESTNET_PUBLIC_EXTENDED_KEY,
 };
 pub use self::hd_wallet::{bip32_path, bip44_path, BSV_COIN_TYPE, HdWallet};
+pub use self::hd_watch_wallet::{
+    scan_address_indices, watch_bip32_path, watch_bip44_path, DEFAULT_GAP_LIMIT, HdWatchWallet,
+};
 pub use self::mnemonic::{
     load_wordlist, mnemonic_decode, mnemonic_encode, mnemonic_parse, mnemonic_to_seed,
     mnemonic_to_seed_validated, Wordlist, BIP39_PBKDF2_ITERATIONS, BIP39_SALT_PREFIX,


### PR DESCRIPTION
## Summary
- Skip invalid BIP-32 child indices automatically in `derive_private_key` / `derive_public_key`
- Add `HdWatchWallet` for account-level `xpub` address derivation and gap-limit scanning
- Add `HdWallet::scan_external_addresses` and Python `HdWatchWallet` bindings

Stacks on #108 (→ #107 → #106).

## Test plan
- [x] `cargo test hd_watch`
- [x] `cargo test extended_key::tests::path`
- [x] Python `unittest test_hd_wallet` (includes watch wallet test)


Made with [Cursor](https://cursor.com)