### PR TITLE
Document BIP-32 HD wallets

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -14,6 +14,7 @@ pip install tx-engine
 |-------|------|
 | Documentation index | [docs/README.md](docs/README.md) |
 | Python class reference | [docs/Python-API.md](docs/Python-API.md) |
+| HD wallets (mnemonic, BIP-44) | [docs/BIP-32-Python.md](docs/BIP-32-Python.md) |
 | Chronicle (Python examples) | [docs/Chronicle-Python.md](docs/Chronicle-Python.md) |
 | Chronicle (full spec) | [docs/Chronicle.md](docs/Chronicle.md) |
 | Local development | [python/README.md](python/README.md) |
@@ -48,3 +49,14 @@ Chronicle script rules apply when **`tx.version > 1`**. Use `version: 2` (or hig
 | Script debugger / partial eval | `Context(tx_version=2, lock_script=...)` |
 
 See [docs/Chronicle.md](docs/Chronicle.md) for sighash routing, opcodes, two-phase evaluation, malleability rules, and script number limits.
+
+## HD wallets
+
+BIP-32 / BIP-39 / BIP-44 support via `HdWallet` and watch-only `HdWatchWallet`. Guide: [docs/BIP-32-Python.md](docs/BIP-32-Python.md).
+
+```python
+from tx_engine import HdWallet, bsv_coin_type
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", "abandon abandon ... about")
+print(hd.address_at_bip44(bsv_coin_type(), 0, True, 0))
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full documentation index: [docs/README.md](docs/README.md).
 
 **All chains:** P2P messages, address encoding, node connections, mainnet/testnet.
 
-**BSV only:** transaction signing, script evaluation, wallet/key derivation, Genesis upgrade, [Chronicle upgrade](docs/Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules).
+**BSV only:** transaction signing, script evaluation, wallet/key derivation (BIP-32 HD wallets), Genesis upgrade, [Chronicle upgrade](docs/Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules).
 
 ## Rust usage
 
@@ -46,7 +46,7 @@ Chronicle helpers: `chain_gang::chronicle` — see [docs/Chronicle.md](docs/Chro
 pip install tx-engine   # Python 3.11+
 ```
 
-PyPI shows [README-pypi.md](README-pypi.md). Class reference: [docs/Python-API.md](docs/Python-API.md). Chronicle examples: [docs/Chronicle-Python.md](docs/Chronicle-Python.md). Local dev: [python/README.md](python/README.md).
+PyPI shows [README-pypi.md](README-pypi.md). Class reference: [docs/Python-API.md](docs/Python-API.md). Chronicle examples: [docs/Chronicle-Python.md](docs/Chronicle-Python.md). HD wallets: [docs/BIP-32.md](docs/BIP-32.md). Local dev: [python/README.md](python/README.md).
 
 ## Development
 

--- a/docs/BIP-32-Python.md
+++ b/docs/BIP-32-Python.md
@@ -1,0 +1,68 @@
+# BIP-32 (Python)
+
+Short Python-focused guide for HD wallets in **tx-engine**. Full spec and Rust examples: [BIP-32.md](BIP-32.md). Class reference: [Python-API.md](Python-API.md#hdwallet).
+
+## Mnemonic → addresses
+
+```python
+from tx_engine import HdWallet, bip44_path, bsv_coin_type
+
+mnemonic = (
+    "abandon abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon about"
+)
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic, passphrase="")
+
+# First BIP-44 external address (m/44'/236'/0'/0/0)
+print(hd.address_at_bip44(bsv_coin_type(), 0, True, 0))
+
+# Signing wallet at that path
+wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
+print(wallet.get_address())
+```
+
+## Watch-only `xpub`
+
+Export the account `xpub` from a full wallet, then derive addresses without private keys:
+
+```python
+from tx_engine import HdWallet, HdWatchWallet
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic)
+account_xpub = hd.derive_xpub("m/0'")
+
+watch = HdWatchWallet.from_xpub(account_xpub)
+print(watch.address_at(True, 0))   # M/0/0 relative to account xpub
+print(watch.derive_xpub("M/0/1"))  # extended public key at child path
+```
+
+## Gap-limit discovery
+
+Scan receive indices until `gap_limit` consecutive unused addresses (typical value: 20):
+
+```python
+known_on_chain = {"1A...", "1B..."}
+
+used = watch.scan_addresses(
+    True,   # external (receive) chain
+    20,     # gap limit
+    lambda addr: addr in known_on_chain,
+)
+```
+
+Full wallets can scan per account:
+
+```python
+used = hd.scan_external_addresses(account=0, gap_limit=20, is_used=lambda a: a in known_on_chain)
+```
+
+## Module helpers
+
+| Function | Purpose |
+|----------|---------|
+| `mnemonic_to_seed(mnemonic, passphrase)` | 64-byte seed (does not validate words) |
+| `derive_extended_key(xprv, path)` | Derive `xprv` along `m/...` path |
+| `bip32_path`, `bip44_path` | Build standard paths |
+| `watch_bip32_path`, `watch_bip44_path` | Paths relative to account `xpub` |
+| `bsv_coin_type()` | Returns `236` |

--- a/docs/BIP-32.md
+++ b/docs/BIP-32.md
@@ -1,0 +1,102 @@
+# BIP-32 HD wallets
+
+Guide for hierarchical deterministic (HD) wallets in **chain-gang** (Rust) and **tx-engine** (Python). Implements [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) key derivation, [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) mnemonics, and [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) style paths. BSV mainnet coin type **236** ([SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)).
+
+Python class reference: [Python-API.md](Python-API.md#hdwallet). Rust API: `chain_gang::wallet`.
+
+## Concepts
+
+| Piece | Role |
+|-------|------|
+| Seed | 64-byte output of BIP-39 PBKDF2 (or any ≥16-byte seed for BIP-32 master) |
+| `xprv` / `xpub` | Base58 extended private / public keys |
+| Path `m/...` | Private derivation from master `xprv` (hardened steps allowed) |
+| Path `M/...` | Public derivation from `xpub` (no hardened children) |
+| `HdWallet` | Full wallet — derive signing keys and addresses |
+| `HdWatchWallet` | Watch-only from account-level `xpub` — addresses only |
+
+Invalid BIP-32 child indices are skipped automatically (next index is tried per the spec).
+
+## Rust
+
+```rust
+use chain_gang::network::Network;
+use chain_gang::wallet::{
+    bip32_path, bip44_path, load_wordlist, master_extended_key_from_seed, BSV_COIN_TYPE,
+    HdWallet, HdWatchWallet, Wordlist,
+};
+
+// From BIP-39 mnemonic (English word list)
+let wordlist = load_wordlist(Wordlist::English);
+let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+let hd = HdWallet::from_mnemonic(Network::BSV_Mainnet, mnemonic, "", &wordlist)?;
+
+// Or from seed bytes
+let seed = chain_gang::wallet::mnemonic_to_seed_validated(mnemonic, "", &wordlist)?;
+let hd = HdWallet::from_seed(Network::BSV_Mainnet, &seed)?;
+
+// BIP-44 receive address (m/44'/236'/0'/0/0)
+let addr = hd.address_at_bip44(BSV_COIN_TYPE, 0, true, 0)?;
+
+// Leaf signing wallet at m/0'/0/0
+let wallet = hd.wallet_at_path(&bip32_path(0, 0, 0))?;
+
+// Watch-only from account xpub (m/0')
+let account_xpub = hd.derive_path("m/0'")?.extended_public_key()?.encode();
+let watch = HdWatchWallet::from_xpub(&account_xpub)?;
+let same_addr = watch.address_at(true, 0)?;
+
+// Gap-limit scan (e.g. 20 unused indices after last used)
+let used = watch.scan_addresses(true, 20, |a| a == &addr)?;
+```
+
+Core helpers without `HdWallet`:
+
+```rust
+let master = master_extended_key_from_seed(Network::BSV_Mainnet, &seed)?;
+let child = chain_gang::wallet::derive_extended_key(&master, "m/0'/0/0")?;
+```
+
+## Python
+
+```python
+from tx_engine import (
+    HdWallet,
+    HdWatchWallet,
+    bip44_path,
+    bsv_coin_type,
+    mnemonic_to_seed,
+)
+
+mnemonic = (
+    "abandon abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon about"
+)
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic)
+addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
+wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
+
+# Watch-only from account xpub
+account_xpub = hd.derive_xpub("m/0'")
+watch = HdWatchWallet.from_xpub(account_xpub)
+assert watch.address_at(True, 0) == addr
+
+# Gap scan: callable returns True if address was used on-chain
+used = watch.scan_addresses(True, 20, lambda a: a in my_known_addresses)
+```
+
+## Path helpers
+
+| Rust | Python | Example output |
+|------|--------|----------------|
+| `bip32_path(0, 0, 5)` | `bip32_path(0, 0, 5)` | `m/0'/0/5` |
+| `bip44_path(236, 0, true, 5)` | `bip44_path(bsv_coin_type(), 0, True, 5)` | `m/44'/236'/0'/0/5` |
+| `watch_bip32_path(0, 5)` | `watch_bip32_path(0, 5)` | `M/0/5` (from account `xpub`) |
+| `watch_bip44_path(true, 5)` | `watch_bip44_path(True, 5)` | `M/0/5` |
+
+## See also
+
+- [Python-API.md](Python-API.md) — `Wallet`, `HdWallet`, `HdWatchWallet`
+- [README-chain-gang.md](README-chain-gang.md) — crate overview
+- BIP-32 test vectors 1–3 are covered in `extended_key` unit tests

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -276,6 +276,7 @@ Watch-only BIP-32 wallet from an account-level `xpub`. Use relative paths (`M/0/
 * `address_at(external: bool, index: int) -> str` — relative `M/{change}/{index}`
 * `address_at_bip44(external: bool, index: int) -> str`
 * `address_at_path(path: str) -> str`
+* `derive_xpub(path: str) -> str`
 * `scan_addresses(external: bool, gap_limit: int, is_used: callable) -> List[str]` — gap-limit discovery; `is_used(address)` returns whether the address has been seen on-chain
 
 Path helpers for account-level `xpub`:

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -54,7 +54,19 @@ To build the library with the `python` feature
 ```bash
 cargo build --features "python"
 ```
-For more details of the `python` feature see [python/README.md](../python/README.md). Full documentation index: [docs/README.md](README.md).
+For more details of the `python` feature see [python/README.md](../python/README.md). Full documentation index: [docs/README.md](README.md). HD wallets: [BIP-32.md](BIP-32.md).
+
+## HD wallets (BIP-32)
+
+```rust
+use chain_gang::network::Network;
+use chain_gang::wallet::{HdWallet, bip44_path, BSV_COIN_TYPE};
+
+let hd = HdWallet::from_seed(Network::BSV_Mainnet, &seed)?;
+let addr = hd.address_at_bip44(BSV_COIN_TYPE, 0, true, 0)?;
+```
+
+See [BIP-32.md](BIP-32.md) for mnemonics, watch-only `xpub`, and gap-limit scanning.
 
 # Known limitations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,12 +18,14 @@ Index for **chain-gang** (Rust library) and **tx-engine** (Python bindings).
 | [Python-API.md](Python-API.md) | **Python class reference** — Script, Tx, Context, Wallet, interfaces |
 | [python/README.md](../python/README.md) | Python package layout, local dev, and tests |
 | [Chronicle-Python.md](Chronicle-Python.md) | **Python Chronicle guide** — examples for Context, Tx, signing, helpers |
+| [BIP-32-Python.md](BIP-32-Python.md) | **Python HD wallet guide** — mnemonic, `HdWallet`, watch-only `xpub`, gap scan |
 | [Chronicle.md](Chronicle.md) | Chronicle upgrade: sighash, opcodes, validation modes, Rust API |
 
 **Quick links**
 
 - Install: `pip install tx-engine` (Python 3.11+)
 - Chronicle validation: [Chronicle-Python.md](Chronicle-Python.md) — `Tx.validate()`, `Tx.validate_at_height()`, `Context`
+- HD wallets: [BIP-32-Python.md](BIP-32-Python.md) — `HdWallet`, `HdWatchWallet`, mnemonic
 - Class reference: [Python-API.md](Python-API.md)
 - Node RPC flag reference: `tx_engine.interface.verify_script`
 
@@ -32,6 +34,7 @@ Index for **chain-gang** (Rust library) and **tx-engine** (Python bindings).
 | Document | Description |
 |----------|-------------|
 | [README-chain-gang.md](README-chain-gang.md) | Crate overview, feature flags, installation |
+| [BIP-32.md](BIP-32.md) | HD wallets — BIP-32/39/44, `HdWallet`, watch-only `xpub`, Rust + Python |
 | [Chronicle.md](Chronicle.md) | Same Chronicle spec; Rust examples use `chain_gang::chronicle` |
 | [docs.rs](https://docs.rs/chain-gang) | Generated Rust API (`chain_gang::chronicle`, `Tx::validate_at_height`, etc.) |
 

--- a/python/src/tests/test_hd_wallet.py
+++ b/python/src/tests/test_hd_wallet.py
@@ -44,6 +44,7 @@ class HdWalletTest(unittest.TestCase):
             watch.address_at(True, 0),
             hd.address_at(0, True, 0),
         )
+        self.assertEqual(watch.derive_xpub("M/0/0"), hd.derive_xpub(bip32_path(0, 0, 0)))
 
 
 if __name__ == "__main__":

--- a/src/python/py_hd_wallet.rs
+++ b/src/python/py_hd_wallet.rs
@@ -130,6 +130,10 @@ impl PyHdWatchWallet {
     Ok(self.inner.address_at_path(path)?)
   }
 
+  fn derive_xpub(&self, path: &str) -> PyResult<String> {
+    Ok(self.inner.derive_path(path)?.encode())
+  }
+
   fn scan_addresses(
     &self,
     external: bool,


### PR DESCRIPTION
## Summary
- Add `docs/BIP-32.md` (Rust + Python) and `docs/BIP-32-Python.md`
- Link guides from docs index, GitHub README, PyPI readme, and crates.io readme
- Add `HdWatchWallet.derive_xpub` Python binding

Stacks on #109 (→ #108 → #107 → #106).

## Test plan
- [x] Python `unittest test_hd_wallet`


Made with [Cursor](https://cursor.com)