### PR TITLE
Update Cargo and Python dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ async-mutex = { version = "1.4.1", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 
 # For python feature
-pyo3 = { version = "0.28.2", optional = true }
+pyo3 = { version = "0.29.0", optional = true }
 regex = "1.12.4"
 lazy_static = "1.5.0"
 rand_core = "0.9.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1.5"
 dns-lookup = "3.0.1"
 hex = "0.4.3"
 linked-hash-map = "0.5"
-log = { version = "0.4.29", features = ["max_level_trace", "release_max_level_warn"] }
+log = { version = "0.4.32", features = ["max_level_trace", "release_max_level_warn"] }
 db-key = "0.0.5"  # this is a non-trival update
 thiserror = "2.0.18"
 url = "2.5.8"
@@ -38,16 +38,16 @@ pbkdf2 = "0.12.2"
 # Used by the interface feature
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = { version = "1.0.150", optional = true }
-reqwest = { version = "0.13.3", features = ["json"], optional = true }
+reqwest = { version = "0.13.4", features = ["json"], optional = true }
 async-mutex = { version = "1.4.1", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 
 # For python feature
-pyo3 = { version = "0.27.2", optional = true }
-regex = "^1.12.3"
+pyo3 = { version = "0.28.2", optional = true }
+regex = "1.12.4"
 lazy_static = "1.5.0"
 rand_core = "0.9.5"
-typenum = "1.20.0"
+typenum = "1.20.1"
 
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-dependencies = ["requests==2.34.2", "python-bitcoinrpc==1.0", "cryptography==48.0.0"]
+dependencies = ["requests==2.34.2", "python-bitcoinrpc==1.0", "cryptography==49.0.0"]
 
 [tool.maturin]
 features = ["pyo3/extension-module", "python"]


### PR DESCRIPTION
## Summary
- **Rust:** `log` 0.4.32, `reqwest` 0.13.4, `pyo3` 0.29.0, `regex` 1.12.4, `typenum` 1.20.1
- **Python:** `cryptography` 49.0.0 (`requests` already at latest 2.34.2)

**Intentionally not bumped** (needs separate work):
- `k256` / `rand` — 0.14 migration pending
- `pbkdf2` 0.13 — digest stack alignment

`Cargo.lock` is gitignored; CI resolves deps from `Cargo.toml` pins.

## Test plan
- [x] `cargo test --all-features`
- [x] `maturin develop --features python`
- [x] Python unittest suite (venv)