### PR TITLE
Release v0.9.0 — BIP-32 HD wallets and dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-gang"
-version = "0.8.0"
+version = "0.9.0"
 description = "This is a library that enables monitoring of multiple blockchains (BTC, BCH, BSV)."
 # repository = "https://github.com/brentongunning/rust-sv"
 authors = ["Arthur Gordon <a.gordon@nchain.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ byteorder = "1.5"
 dns-lookup = "3.0.1"
 hex = "0.4.3"
 linked-hash-map = "0.5"
-log = { version = "0.4.29", features = ["max_level_trace", "release_max_level_warn"] }
+log = { version = "0.4.32", features = ["max_level_trace", "release_max_level_warn"] }
 db-key = "0.0.5"  # this is a non-trival update
 thiserror = "2.0.18"
 url = "2.5.8"
@@ -38,16 +38,16 @@ pbkdf2 = "0.12.2"
 # Used by the interface feature
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = { version = "1.0.150", optional = true }
-reqwest = { version = "0.13.3", features = ["json"], optional = true }
+reqwest = { version = "0.13.4", features = ["json"], optional = true }
 async-mutex = { version = "1.4.1", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 
 # For python feature
-pyo3 = { version = "0.27.2", optional = true }
-regex = "^1.12.3"
+pyo3 = { version = "0.28.2", optional = true }
+regex = "1.12.4"
 lazy_static = "1.5.0"
 rand_core = "0.9.5"
-typenum = "1.20.0"
+typenum = "1.20.1"
 
 
 [lib]

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -14,6 +14,7 @@ pip install tx-engine
 |-------|------|
 | Documentation index | [docs/README.md](docs/README.md) |
 | Python class reference | [docs/Python-API.md](docs/Python-API.md) |
+| HD wallets (mnemonic, BIP-44) | [docs/BIP-32-Python.md](docs/BIP-32-Python.md) |
 | Chronicle (Python examples) | [docs/Chronicle-Python.md](docs/Chronicle-Python.md) |
 | Chronicle (full spec) | [docs/Chronicle.md](docs/Chronicle.md) |
 | Local development | [python/README.md](python/README.md) |
@@ -48,3 +49,14 @@ Chronicle script rules apply when **`tx.version > 1`**. Use `version: 2` (or hig
 | Script debugger / partial eval | `Context(tx_version=2, lock_script=...)` |
 
 See [docs/Chronicle.md](docs/Chronicle.md) for sighash routing, opcodes, two-phase evaluation, malleability rules, and script number limits.
+
+## HD wallets
+
+BIP-32 / BIP-39 / BIP-44 support via `HdWallet` and watch-only `HdWatchWallet`. Guide: [docs/BIP-32-Python.md](docs/BIP-32-Python.md).
+
+```python
+from tx_engine import HdWallet, bsv_coin_type
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", "abandon abandon ... about")
+print(hd.address_at_bip44(bsv_coin_type(), 0, True, 0))
+```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full documentation index: [docs/README.md](docs/README.md).
 
 **All chains:** P2P messages, address encoding, node connections, mainnet/testnet.
 
-**BSV only:** transaction signing, script evaluation, wallet/key derivation, Genesis upgrade, [Chronicle upgrade](docs/Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules).
+**BSV only:** transaction signing, script evaluation, wallet/key derivation (BIP-32 HD wallets), Genesis upgrade, [Chronicle upgrade](docs/Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules).
 
 ## Rust usage
 
@@ -46,7 +46,7 @@ Chronicle helpers: `chain_gang::chronicle` — see [docs/Chronicle.md](docs/Chro
 pip install tx-engine   # Python 3.11+
 ```
 
-PyPI shows [README-pypi.md](README-pypi.md). Class reference: [docs/Python-API.md](docs/Python-API.md). Chronicle examples: [docs/Chronicle-Python.md](docs/Chronicle-Python.md). Local dev: [python/README.md](python/README.md).
+PyPI shows [README-pypi.md](README-pypi.md). Class reference: [docs/Python-API.md](docs/Python-API.md). Chronicle examples: [docs/Chronicle-Python.md](docs/Chronicle-Python.md). HD wallets: [docs/BIP-32.md](docs/BIP-32.md). Local dev: [python/README.md](python/README.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Full documentation index: [docs/README.md](docs/README.md).
 Add to `Cargo.toml`:
 
 ```toml
-chain-gang = "0.7"
+chain-gang = "0.9"
 ```
 
 Build with optional features:

--- a/docs/BIP-32-Python.md
+++ b/docs/BIP-32-Python.md
@@ -1,0 +1,68 @@
+# BIP-32 (Python)
+
+Short Python-focused guide for HD wallets in **tx-engine**. Full spec and Rust examples: [BIP-32.md](BIP-32.md). Class reference: [Python-API.md](Python-API.md#hdwallet).
+
+## Mnemonic → addresses
+
+```python
+from tx_engine import HdWallet, bip44_path, bsv_coin_type
+
+mnemonic = (
+    "abandon abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon about"
+)
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic, passphrase="")
+
+# First BIP-44 external address (m/44'/236'/0'/0/0)
+print(hd.address_at_bip44(bsv_coin_type(), 0, True, 0))
+
+# Signing wallet at that path
+wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
+print(wallet.get_address())
+```
+
+## Watch-only `xpub`
+
+Export the account `xpub` from a full wallet, then derive addresses without private keys:
+
+```python
+from tx_engine import HdWallet, HdWatchWallet
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic)
+account_xpub = hd.derive_xpub("m/0'")
+
+watch = HdWatchWallet.from_xpub(account_xpub)
+print(watch.address_at(True, 0))   # M/0/0 relative to account xpub
+print(watch.derive_xpub("M/0/1"))  # extended public key at child path
+```
+
+## Gap-limit discovery
+
+Scan receive indices until `gap_limit` consecutive unused addresses (typical value: 20):
+
+```python
+known_on_chain = {"1A...", "1B..."}
+
+used = watch.scan_addresses(
+    True,   # external (receive) chain
+    20,     # gap limit
+    lambda addr: addr in known_on_chain,
+)
+```
+
+Full wallets can scan per account:
+
+```python
+used = hd.scan_external_addresses(account=0, gap_limit=20, is_used=lambda a: a in known_on_chain)
+```
+
+## Module helpers
+
+| Function | Purpose |
+|----------|---------|
+| `mnemonic_to_seed(mnemonic, passphrase)` | 64-byte seed (does not validate words) |
+| `derive_extended_key(xprv, path)` | Derive `xprv` along `m/...` path |
+| `bip32_path`, `bip44_path` | Build standard paths |
+| `watch_bip32_path`, `watch_bip44_path` | Paths relative to account `xpub` |
+| `bsv_coin_type()` | Returns `236` |

--- a/docs/BIP-32.md
+++ b/docs/BIP-32.md
@@ -1,0 +1,102 @@
+# BIP-32 HD wallets
+
+Guide for hierarchical deterministic (HD) wallets in **chain-gang** (Rust) and **tx-engine** (Python). Implements [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) key derivation, [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) mnemonics, and [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) style paths. BSV mainnet coin type **236** ([SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)).
+
+Python class reference: [Python-API.md](Python-API.md#hdwallet). Rust API: `chain_gang::wallet`.
+
+## Concepts
+
+| Piece | Role |
+|-------|------|
+| Seed | 64-byte output of BIP-39 PBKDF2 (or any ≥16-byte seed for BIP-32 master) |
+| `xprv` / `xpub` | Base58 extended private / public keys |
+| Path `m/...` | Private derivation from master `xprv` (hardened steps allowed) |
+| Path `M/...` | Public derivation from `xpub` (no hardened children) |
+| `HdWallet` | Full wallet — derive signing keys and addresses |
+| `HdWatchWallet` | Watch-only from account-level `xpub` — addresses only |
+
+Invalid BIP-32 child indices are skipped automatically (next index is tried per the spec).
+
+## Rust
+
+```rust
+use chain_gang::network::Network;
+use chain_gang::wallet::{
+    bip32_path, bip44_path, load_wordlist, master_extended_key_from_seed, BSV_COIN_TYPE,
+    HdWallet, HdWatchWallet, Wordlist,
+};
+
+// From BIP-39 mnemonic (English word list)
+let wordlist = load_wordlist(Wordlist::English);
+let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+let hd = HdWallet::from_mnemonic(Network::BSV_Mainnet, mnemonic, "", &wordlist)?;
+
+// Or from seed bytes
+let seed = chain_gang::wallet::mnemonic_to_seed_validated(mnemonic, "", &wordlist)?;
+let hd = HdWallet::from_seed(Network::BSV_Mainnet, &seed)?;
+
+// BIP-44 receive address (m/44'/236'/0'/0/0)
+let addr = hd.address_at_bip44(BSV_COIN_TYPE, 0, true, 0)?;
+
+// Leaf signing wallet at m/0'/0/0
+let wallet = hd.wallet_at_path(&bip32_path(0, 0, 0))?;
+
+// Watch-only from account xpub (m/0')
+let account_xpub = hd.derive_path("m/0'")?.extended_public_key()?.encode();
+let watch = HdWatchWallet::from_xpub(&account_xpub)?;
+let same_addr = watch.address_at(true, 0)?;
+
+// Gap-limit scan (e.g. 20 unused indices after last used)
+let used = watch.scan_addresses(true, 20, |a| a == &addr)?;
+```
+
+Core helpers without `HdWallet`:
+
+```rust
+let master = master_extended_key_from_seed(Network::BSV_Mainnet, &seed)?;
+let child = chain_gang::wallet::derive_extended_key(&master, "m/0'/0/0")?;
+```
+
+## Python
+
+```python
+from tx_engine import (
+    HdWallet,
+    HdWatchWallet,
+    bip44_path,
+    bsv_coin_type,
+    mnemonic_to_seed,
+)
+
+mnemonic = (
+    "abandon abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon about"
+)
+
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic)
+addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
+wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
+
+# Watch-only from account xpub
+account_xpub = hd.derive_xpub("m/0'")
+watch = HdWatchWallet.from_xpub(account_xpub)
+assert watch.address_at(True, 0) == addr
+
+# Gap scan: callable returns True if address was used on-chain
+used = watch.scan_addresses(True, 20, lambda a: a in my_known_addresses)
+```
+
+## Path helpers
+
+| Rust | Python | Example output |
+|------|--------|----------------|
+| `bip32_path(0, 0, 5)` | `bip32_path(0, 0, 5)` | `m/0'/0/5` |
+| `bip44_path(236, 0, true, 5)` | `bip44_path(bsv_coin_type(), 0, True, 5)` | `m/44'/236'/0'/0/5` |
+| `watch_bip32_path(0, 5)` | `watch_bip32_path(0, 5)` | `M/0/5` (from account `xpub`) |
+| `watch_bip44_path(true, 5)` | `watch_bip44_path(True, 5)` | `M/0/5` |
+
+## See also
+
+- [Python-API.md](Python-API.md) — `Wallet`, `HdWallet`, `HdWatchWallet`
+- [README-chain-gang.md](README-chain-gang.md) — crate overview
+- BIP-32 test vectors 1–3 are covered in `extended_key` unit tests

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -13,6 +13,7 @@ Class and function reference for **tx-engine**. For install and a quick start, s
 * [TxIn](#txin)
 * [TxOut](#txout)
 * [Wallet](#wallet)
+* [HdWallet](#hdwallet)
 * [Interface Factory](#interface-factory)
 * [Blockchain Interface](#blockchain-interface)
 * [Other Functions](#other-functions)
@@ -218,6 +219,47 @@ The library provides some additional helper functions to handle keys in differen
 
 
 ![Bitcoin Keys](diagrams/keys.png)
+
+
+## HdWallet
+
+BIP-32 hierarchical deterministic wallet. Derive child keys along a path, obtain P2PKH addresses (BIP-44 style), and get a leaf [`Wallet`](#wallet) for signing. Stacks on BIP-39 mnemonic support (`mnemonic_to_seed`).
+
+`HdWallet` class methods:
+
+* `HdWallet.from_seed(network: str, seed: bytes) -> HdWallet` - Master key from a 64-byte BIP-39 seed
+* `HdWallet.from_mnemonic(network: str, mnemonic: str, passphrase: str = "") -> HdWallet` - English BIP-39 mnemonic (validated) then seed derivation
+* `HdWallet.from_xprv(xprv: str) -> HdWallet` - Root from an encoded extended private key (`xprv...`)
+
+`HdWallet` methods:
+
+* `master_xprv() -> str` - Encoded master extended private key
+* `master_xpub() -> str` - Encoded master extended public key
+* `address_at(account: int, external: bool, index: int) -> str` - P2PKH address at `m/{account}'/{change}/{index}` (`external=True` → change 0)
+* `address_at_bip44(coin_type: int, account: int, external: bool, index: int) -> str` - P2PKH address at a full BIP-44 path
+* `wallet_at_path(path: str) -> Wallet` - Leaf signing wallet at the given path (e.g. `m/0'/0/0`)
+* `derive_xprv(path: str) -> str` - Extended private key at `path`
+* `derive_xpub(path: str) -> str` - Extended public key at `path`
+
+Path helpers (module functions):
+
+* `bip32_path(account: int, change: int, index: int) -> str` - `m/{account}'/{change}/{index}`
+* `bip44_path(coin_type: int, account: int, external: bool, index: int) -> str` - `m/44'/{coin_type}'/{account}'/{change}/{index}`
+* `bsv_coin_type() -> int` - BSV SLIP-44 coin type (`236`)
+* `mnemonic_to_seed(mnemonic: str, passphrase: str) -> bytes` - 64-byte BIP-39 seed (does not validate words)
+* `derive_extended_key(xprv: str, path: str) -> str` - Derive extended private key from master `xprv` and path
+
+Example:
+
+```Python
+from tx_engine import HdWallet, bip44_path, bsv_coin_type, mnemonic_to_seed
+
+mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+hd = HdWallet.from_mnemonic("BSV_Mainnet", mnemonic)
+addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
+wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
+signed_tx = wallet.sign_tx(0, prev_tx, tx)
+```
 
 
 ## Interface Factory

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -14,6 +14,7 @@ Class and function reference for **tx-engine**. For install and a quick start, s
 * [TxOut](#txout)
 * [Wallet](#wallet)
 * [HdWallet](#hdwallet)
+* [HdWatchWallet](#hdwatchwallet)
 * [Interface Factory](#interface-factory)
 * [Blockchain Interface](#blockchain-interface)
 * [Other Functions](#other-functions)
@@ -260,6 +261,29 @@ addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
 wallet = hd.wallet_at_path(bip44_path(bsv_coin_type(), 0, True, 0))
 signed_tx = wallet.sign_tx(0, prev_tx, tx)
 ```
+
+## HdWatchWallet
+
+Watch-only BIP-32 wallet from an account-level `xpub`. Use relative paths (`M/0/0`) for receive/change indices. Cannot sign transactions.
+
+`HdWatchWallet` class methods:
+
+* `HdWatchWallet.from_xpub(xpub: str) -> HdWatchWallet`
+
+`HdWatchWallet` methods:
+
+* `master_xpub() -> str`
+* `address_at(external: bool, index: int) -> str` — relative `M/{change}/{index}`
+* `address_at_bip44(external: bool, index: int) -> str`
+* `address_at_path(path: str) -> str`
+* `scan_addresses(external: bool, gap_limit: int, is_used: callable) -> List[str]` — gap-limit discovery; `is_used(address)` returns whether the address has been seen on-chain
+
+Path helpers for account-level `xpub`:
+
+* `watch_bip32_path(change: int, index: int) -> str`
+* `watch_bip44_path(external: bool, index: int) -> str`
+
+`HdWallet.scan_external_addresses(account, gap_limit, is_used)` scans receive addresses for a full HD wallet.
 
 
 ## Interface Factory

--- a/docs/Python-API.md
+++ b/docs/Python-API.md
@@ -276,6 +276,7 @@ Watch-only BIP-32 wallet from an account-level `xpub`. Use relative paths (`M/0/
 * `address_at(external: bool, index: int) -> str` — relative `M/{change}/{index}`
 * `address_at_bip44(external: bool, index: int) -> str`
 * `address_at_path(path: str) -> str`
+* `derive_xpub(path: str) -> str`
 * `scan_addresses(external: bool, gap_limit: int, is_used: callable) -> List[str]` — gap-limit discovery; `is_used(address)` returns whether the address has been seen on-chain
 
 Path helpers for account-level `xpub`:

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -54,7 +54,19 @@ To build the library with the `python` feature
 ```bash
 cargo build --features "python"
 ```
-For more details of the `python` feature see [python/README.md](../python/README.md). Full documentation index: [docs/README.md](README.md).
+For more details of the `python` feature see [python/README.md](../python/README.md). Full documentation index: [docs/README.md](README.md). HD wallets: [BIP-32.md](BIP-32.md).
+
+## HD wallets (BIP-32)
+
+```rust
+use chain_gang::network::Network;
+use chain_gang::wallet::{HdWallet, bip44_path, BSV_COIN_TYPE};
+
+let hd = HdWallet::from_seed(Network::BSV_Mainnet, &seed)?;
+let addr = hd.address_at_bip44(BSV_COIN_TYPE, 0, true, 0)?;
+```
+
+See [BIP-32.md](BIP-32.md) for mnemonics, watch-only `xpub`, and gap-limit scanning.
 
 # Known limitations
 

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -22,7 +22,7 @@ Features (all blockchains)
 BSV only Features
 * Transaction signing 
 * Script evaluation 
-* Wallet key derivation and mnemonic parsing
+* Wallet key derivation, BIP-32 HD wallets (`HdWallet`), and mnemonic parsing
 * Various Bitcoin primitives
 * Genesis upgrade support
 * [Chronicle upgrade](Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,12 +18,14 @@ Index for **chain-gang** (Rust library) and **tx-engine** (Python bindings).
 | [Python-API.md](Python-API.md) | **Python class reference** — Script, Tx, Context, Wallet, interfaces |
 | [python/README.md](../python/README.md) | Python package layout, local dev, and tests |
 | [Chronicle-Python.md](Chronicle-Python.md) | **Python Chronicle guide** — examples for Context, Tx, signing, helpers |
+| [BIP-32-Python.md](BIP-32-Python.md) | **Python HD wallet guide** — mnemonic, `HdWallet`, watch-only `xpub`, gap scan |
 | [Chronicle.md](Chronicle.md) | Chronicle upgrade: sighash, opcodes, validation modes, Rust API |
 
 **Quick links**
 
 - Install: `pip install tx-engine` (Python 3.11+)
 - Chronicle validation: [Chronicle-Python.md](Chronicle-Python.md) — `Tx.validate()`, `Tx.validate_at_height()`, `Context`
+- HD wallets: [BIP-32-Python.md](BIP-32-Python.md) — `HdWallet`, `HdWatchWallet`, mnemonic
 - Class reference: [Python-API.md](Python-API.md)
 - Node RPC flag reference: `tx_engine.interface.verify_script`
 
@@ -32,6 +34,7 @@ Index for **chain-gang** (Rust library) and **tx-engine** (Python bindings).
 | Document | Description |
 |----------|-------------|
 | [README-chain-gang.md](README-chain-gang.md) | Crate overview, feature flags, installation |
+| [BIP-32.md](BIP-32.md) | HD wallets — BIP-32/39/44, `HdWallet`, watch-only `xpub`, Rust + Python |
 | [Chronicle.md](Chronicle.md) | Same Chronicle spec; Rust examples use `chain_gang::chronicle` |
 | [docs.rs](https://docs.rs/chain-gang) | Generated Rust API (`chain_gang::chronicle`, `Tx::validate_at_height`, etc.) |
 

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -52,3 +52,4 @@
 * v0.7.5 - Updated Python dependencies cryptography and requests
 * v0.7.6 - Removed the use of LRU cache around WoCInterface for get_raw_transaction
 * v0.8.0 - BSV Chronicle support (OTDA sighash, opcodes, two-phase eval, height-aware validation, Python bindings), documentation overhaul, Python 3.11–3.14 CI matrix
+* v0.9.0 - BIP-32 HD wallets (`HdWallet`, `HdWatchWallet`, BIP-39 mnemonic seed, Python bindings), watch-only `xpub` and gap-limit scanning, BIP-32 documentation; dependency updates (`pyo3` 0.28.2, `cryptography` 49.0.0, `log`, `reqwest`, `regex`, `typenum`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-dependencies = ["requests==2.34.2", "python-bitcoinrpc==1.0", "cryptography==48.0.0"]
+dependencies = ["requests==2.34.2", "python-bitcoinrpc==1.0", "cryptography==49.0.0"]
 
 [tool.maturin]
 features = ["pyo3/extension-module", "python"]

--- a/python/src/tests/test_hd_wallet.py
+++ b/python/src/tests/test_hd_wallet.py
@@ -1,0 +1,41 @@
+""" HdWallet and BIP-32 Python binding tests
+"""
+import unittest
+
+from tx_engine import HdWallet, bip32_path, bip44_path, bsv_coin_type, derive_extended_key, mnemonic_to_seed
+
+
+ABANDON_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon about"
+)
+
+
+class HdWalletTest(unittest.TestCase):
+    """ HdWallet Python API
+    """
+
+    def test_mnemonic_to_seed_vector(self):
+        seed = mnemonic_to_seed(ABANDON_MNEMONIC, "")
+        self.assertEqual(len(seed), 64)
+
+    def test_hd_wallet_from_mnemonic_address(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        addr = hd.address_at_bip44(bsv_coin_type(), 0, True, 0)
+        self.assertTrue(len(addr) > 20)
+
+    def test_wallet_at_path_signs(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        wallet = hd.wallet_at_path(bip32_path(0, 0, 0))
+        self.assertEqual(wallet.get_network(), "BSV_Mainnet")
+        self.assertTrue(wallet.get_address())
+
+    def test_derive_extended_key_matches_hd(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        path = bip44_path(bsv_coin_type(), 0, True, 1)
+        xprv = hd.derive_xprv(path)
+        self.assertEqual(derive_extended_key(hd.master_xprv(), path), xprv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/src/tests/test_hd_wallet.py
+++ b/python/src/tests/test_hd_wallet.py
@@ -2,7 +2,7 @@
 """
 import unittest
 
-from tx_engine import HdWallet, bip32_path, bip44_path, bsv_coin_type, derive_extended_key, mnemonic_to_seed
+from tx_engine import HdWallet, HdWatchWallet, bip32_path, bip44_path, bsv_coin_type, derive_extended_key, mnemonic_to_seed
 
 
 ABANDON_MNEMONIC = (
@@ -35,6 +35,15 @@ class HdWalletTest(unittest.TestCase):
         path = bip44_path(bsv_coin_type(), 0, True, 1)
         xprv = hd.derive_xprv(path)
         self.assertEqual(derive_extended_key(hd.master_xprv(), path), xprv)
+
+    def test_watch_wallet_from_account_xpub(self):
+        hd = HdWallet.from_mnemonic("BSV_Mainnet", ABANDON_MNEMONIC)
+        account_xpub = hd.derive_xpub("m/0'")
+        watch = HdWatchWallet.from_xpub(account_xpub)
+        self.assertEqual(
+            watch.address_at(True, 0),
+            hd.address_at(0, True, 0),
+        )
 
 
 if __name__ == "__main__":

--- a/python/src/tests/test_hd_wallet.py
+++ b/python/src/tests/test_hd_wallet.py
@@ -44,6 +44,7 @@ class HdWalletTest(unittest.TestCase):
             watch.address_at(True, 0),
             hd.address_at(0, True, 0),
         )
+        self.assertEqual(watch.derive_xpub("M/0/0"), hd.derive_xpub(bip32_path(0, 0, 0)))
 
 
 if __name__ == "__main__":

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -3,8 +3,8 @@ This is a tx_engine doc str
 """
 # noqa: F401 - 'x' - imported but unused
 
-from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, HdWallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, mnemonic_to_seed, derive_extended_key, bip32_path, bip44_path, bsv_coin_type  # noqa: F401
+from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, HdWallet, HdWatchWallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, mnemonic_to_seed, derive_extended_key, bip32_path, bip44_path, bsv_coin_type, watch_bip32_path, watch_bip44_path  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401

--- a/python/src/tx_engine/__init__.py
+++ b/python/src/tx_engine/__init__.py
@@ -3,8 +3,8 @@ This is a tx_engine doc str
 """
 # noqa: F401 - 'x' - imported but unused
 
-from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
-from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce  # noqa: F401
+from tx_engine.tx_engine import Tx, TxIn, TxOut, Script, Stack, Wallet, HdWallet, p2pkh_script, hash160, hash256d, address_to_public_key_hash, public_key_to_address  # noqa: F401
+from tx_engine.tx_engine import sig_hash_preimage, sig_hash_preimage_checksig_index, sig_hash, sig_hash_checksig_index, wif_to_bytes, bytes_to_wif, wif_from_pw_nonce, mnemonic_to_seed, derive_extended_key, bip32_path, bip44_path, bsv_coin_type  # noqa: F401
 from tx_engine.engine.context import Context  # noqa: F401
 from tx_engine.engine.util import encode_num, decode_num  # noqa: F401
 from tx_engine.tx.sighash import SIGHASH  # noqa: F401

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -5,6 +5,7 @@ mod op_code_names;
 mod py_script;
 mod py_stack;
 mod py_tx;
+mod py_hd_wallet;
 mod py_wallet;
 
 use crate::{
@@ -14,6 +15,10 @@ use crate::{
         py_script::PyScript,
         py_stack::{decode_num_stack, PyStack},
         py_tx::{PyTx, PyTxIn, PyTxOut},
+        py_hd_wallet::{
+            py_bip32_path, py_bip44_path, py_bsv_coin_type, py_derive_extended_key,
+            py_mnemonic_to_seed, PyHdWallet,
+        },
         py_wallet::{
             address_to_public_key_hash, bytes_to_wif, generate_wif, p2pkh_pyscript, wif_to_bytes,
             PyWallet,
@@ -470,8 +475,14 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTxIn>()?;
     m.add_class::<PyTxOut>()?;
     m.add_class::<PyTx>()?;
+    m.add_function(wrap_pyfunction!(py_mnemonic_to_seed, m)?)?;
+    m.add_function(wrap_pyfunction!(py_derive_extended_key, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bip32_path, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bip44_path, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bsv_coin_type, m)?)?;
     // Wallet class
     m.add_class::<PyWallet>()?;
+    m.add_class::<PyHdWallet>()?;
     // stack class
     m.add_class::<PyStack>()?;
     Ok(())

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -17,7 +17,8 @@ use crate::{
         py_tx::{PyTx, PyTxIn, PyTxOut},
         py_hd_wallet::{
             py_bip32_path, py_bip44_path, py_bsv_coin_type, py_derive_extended_key,
-            py_mnemonic_to_seed, PyHdWallet,
+            py_mnemonic_to_seed, py_watch_bip32_path, py_watch_bip44_path, PyHdWallet,
+            PyHdWatchWallet,
         },
         py_wallet::{
             address_to_public_key_hash, bytes_to_wif, generate_wif, p2pkh_pyscript, wif_to_bytes,
@@ -480,9 +481,12 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_bip32_path, m)?)?;
     m.add_function(wrap_pyfunction!(py_bip44_path, m)?)?;
     m.add_function(wrap_pyfunction!(py_bsv_coin_type, m)?)?;
+    m.add_function(wrap_pyfunction!(py_watch_bip32_path, m)?)?;
+    m.add_function(wrap_pyfunction!(py_watch_bip44_path, m)?)?;
     // Wallet class
     m.add_class::<PyWallet>()?;
     m.add_class::<PyHdWallet>()?;
+    m.add_class::<PyHdWatchWallet>()?;
     // stack class
     m.add_class::<PyStack>()?;
     Ok(())

--- a/src/python/py_hd_wallet.rs
+++ b/src/python/py_hd_wallet.rs
@@ -3,8 +3,8 @@ use crate::{
     python::py_wallet::{str_to_network, PyWallet},
     util::ChainGangError,
     wallet::{
-        bip32_path, bip44_path, derive_extended_key, load_wordlist, mnemonic_to_seed, Wordlist,
-        BSV_COIN_TYPE, ExtendedKey, HdWallet,
+        bip32_path, bip44_path, derive_extended_key, load_wordlist, mnemonic_to_seed, watch_bip32_path,
+        watch_bip44_path, Wordlist, BSV_COIN_TYPE, ExtendedKey, HdWallet, HdWatchWallet,
     },
 };
 
@@ -87,6 +87,66 @@ impl PyHdWallet {
       .extended_public_key()?
       .encode())
   }
+
+  fn scan_external_addresses(
+    &self,
+    account: u32,
+    gap_limit: u32,
+    is_used: &Bound<'_, PyAny>,
+  ) -> PyResult<Vec<String>> {
+    Ok(self
+      .inner
+      .scan_external_addresses(account, gap_limit, |addr| call_is_used(is_used, addr))?)
+  }
+}
+
+#[pyclass(name = "HdWatchWallet")]
+pub struct PyHdWatchWallet {
+  inner: HdWatchWallet,
+}
+
+#[pymethods]
+impl PyHdWatchWallet {
+  #[classmethod]
+  fn from_xpub(_cls: &Bound<'_, PyType>, xpub: &str) -> PyResult<Self> {
+    Ok(PyHdWatchWallet {
+      inner: HdWatchWallet::from_xpub(xpub)?,
+    })
+  }
+
+  fn master_xpub(&self) -> PyResult<String> {
+    Ok(self.inner.master().encode())
+  }
+
+  fn address_at(&self, external: bool, index: u32) -> PyResult<String> {
+    Ok(self.inner.address_at(external, index)?)
+  }
+
+  fn address_at_bip44(&self, external: bool, index: u32) -> PyResult<String> {
+    Ok(self.inner.address_at_bip44(external, index)?)
+  }
+
+  fn address_at_path(&self, path: &str) -> PyResult<String> {
+    Ok(self.inner.address_at_path(path)?)
+  }
+
+  fn scan_addresses(
+    &self,
+    external: bool,
+    gap_limit: u32,
+    is_used: &Bound<'_, PyAny>,
+  ) -> PyResult<Vec<String>> {
+    Ok(self
+      .inner
+      .scan_addresses(external, gap_limit, |addr| call_is_used(is_used, addr))?)
+  }
+}
+
+fn call_is_used(is_used: &Bound<'_, PyAny>, addr: &str) -> bool {
+  is_used
+    .call1((addr,))
+    .and_then(|v| v.extract::<bool>())
+    .unwrap_or(false)
 }
 
 fn parse_network(network: &str) -> PyResult<Network> {
@@ -119,4 +179,14 @@ pub fn py_bip44_path(coin_type: u32, account: u32, external: bool, index: u32) -
 #[pyfunction(name = "bsv_coin_type")]
 pub fn py_bsv_coin_type() -> u32 {
   BSV_COIN_TYPE
+}
+
+#[pyfunction(name = "watch_bip32_path")]
+pub fn py_watch_bip32_path(change: u32, index: u32) -> String {
+  watch_bip32_path(change, index)
+}
+
+#[pyfunction(name = "watch_bip44_path")]
+pub fn py_watch_bip44_path(external: bool, index: u32) -> String {
+  watch_bip44_path(external, index)
 }

--- a/src/python/py_hd_wallet.rs
+++ b/src/python/py_hd_wallet.rs
@@ -1,0 +1,122 @@
+use crate::{
+    network::Network,
+    python::py_wallet::{str_to_network, PyWallet},
+    util::ChainGangError,
+    wallet::{
+        bip32_path, bip44_path, derive_extended_key, load_wordlist, mnemonic_to_seed, Wordlist,
+        BSV_COIN_TYPE, ExtendedKey, HdWallet,
+    },
+};
+
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+#[pyclass(name = "HdWallet")]
+pub struct PyHdWallet {
+    inner: HdWallet,
+}
+
+#[pymethods]
+impl PyHdWallet {
+  #[classmethod]
+  fn from_seed(_cls: &Bound<'_, PyType>, network: &str, seed: &[u8]) -> PyResult<Self> {
+    let net = parse_network(network)?;
+    Ok(PyHdWallet {
+      inner: HdWallet::from_seed(net, seed)?,
+    })
+  }
+
+  #[classmethod]
+  #[pyo3(signature = (network, mnemonic, passphrase=None))]
+  fn from_mnemonic(
+    _cls: &Bound<'_, PyType>,
+    network: &str,
+    mnemonic: &str,
+    passphrase: Option<&str>,
+  ) -> PyResult<Self> {
+    let net = parse_network(network)?;
+    let wordlist = load_wordlist(Wordlist::English);
+    let pass = passphrase.unwrap_or("");
+    Ok(PyHdWallet {
+      inner: HdWallet::from_mnemonic(net, mnemonic, pass, &wordlist)?,
+    })
+  }
+
+  #[classmethod]
+  fn from_xprv(_cls: &Bound<'_, PyType>, xprv: &str) -> PyResult<Self> {
+    let master = ExtendedKey::decode(xprv)?;
+    Ok(PyHdWallet {
+      inner: HdWallet::from_master(master)?,
+    })
+  }
+
+  fn master_xprv(&self) -> PyResult<String> {
+    Ok(self.inner.master().encode())
+  }
+
+  fn master_xpub(&self) -> PyResult<String> {
+    Ok(self.inner.master().extended_public_key()?.encode())
+  }
+
+  fn address_at(&self, account: u32, external: bool, index: u32) -> PyResult<String> {
+    Ok(self.inner.address_at(account, external, index)?)
+  }
+
+  fn address_at_bip44(
+    &self,
+    coin_type: u32,
+    account: u32,
+    external: bool,
+    index: u32,
+  ) -> PyResult<String> {
+    Ok(self.inner.address_at_bip44(coin_type, account, external, index)?)
+  }
+
+  fn wallet_at_path(&self, path: &str) -> PyResult<PyWallet> {
+    Ok(PyWallet::from_wallet(self.inner.wallet_at_path(path)?))
+  }
+
+  fn derive_xprv(&self, path: &str) -> PyResult<String> {
+    Ok(self.inner.derive_path(path)?.encode())
+  }
+
+  fn derive_xpub(&self, path: &str) -> PyResult<String> {
+    Ok(self
+      .inner
+      .derive_path(path)?
+      .extended_public_key()?
+      .encode())
+  }
+}
+
+fn parse_network(network: &str) -> PyResult<Network> {
+  str_to_network(network).ok_or_else(|| {
+    ChainGangError::BadArgument(format!("Unknown network {}", network)).into()
+  })
+}
+
+#[pyfunction(name = "mnemonic_to_seed")]
+pub fn py_mnemonic_to_seed(mnemonic: &str, passphrase: &str) -> Vec<u8> {
+  mnemonic_to_seed(mnemonic, passphrase).to_vec()
+}
+
+#[pyfunction(name = "derive_extended_key")]
+pub fn py_derive_extended_key(xprv: &str, path: &str) -> PyResult<String> {
+  let master = ExtendedKey::decode(xprv)?;
+  Ok(derive_extended_key(&master, path)?.encode())
+}
+
+#[pyfunction(name = "bip32_path")]
+pub fn py_bip32_path(account: u32, change: u32, index: u32) -> String {
+  bip32_path(account, change, index)
+}
+
+#[pyfunction(name = "bip44_path")]
+pub fn py_bip44_path(coin_type: u32, account: u32, external: bool, index: u32) -> String {
+  bip44_path(coin_type, account, external, index)
+}
+
+#[pyfunction(name = "bsv_coin_type")]
+pub fn py_bsv_coin_type() -> u32 {
+  BSV_COIN_TYPE
+}

--- a/src/python/py_hd_wallet.rs
+++ b/src/python/py_hd_wallet.rs
@@ -130,6 +130,10 @@ impl PyHdWatchWallet {
     Ok(self.inner.address_at_path(path)?)
   }
 
+  fn derive_xpub(&self, path: &str) -> PyResult<String> {
+    Ok(self.inner.derive_path(path)?.encode())
+  }
+
   fn scan_addresses(
     &self,
     external: bool,

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -152,6 +152,12 @@ pub struct PyWallet {
     wallet: Wallet,
 }
 
+impl PyWallet {
+    pub(crate) fn from_wallet(wallet: Wallet) -> Self {
+        PyWallet { wallet }
+    }
+}
+
 #[pymethods]
 impl PyWallet {
     // Given the wif_key, set up the wallet

--- a/src/wallet/extended_key.rs
+++ b/src/wallet/extended_key.rs
@@ -366,11 +366,14 @@ impl ExtendedKey {
         }
 
         let secret_key = SecretKey::from_slice(&hmac[..32])?;
-        let public_key = secret_key.public_key();
-        let child_offset = public_key.to_projective();
-        let child_offset = child_offset.add(child_offset);
-        let child_public_key = PublicKey::<Secp256k1>::try_from(child_offset)?;
-        let child_bytes = child_public_key.to_sec1_bytes();
+        let parent_bytes = self.public_key()?;
+        let parent_pk = PublicKey::<Secp256k1>::from_sec1_bytes(&parent_bytes)
+            .map_err(|_| ChainGangError::BadData("Invalid parent public key".to_string()))?;
+        let offset_pk = secret_key.public_key();
+        let child_point = parent_pk.to_projective() + offset_pk.to_projective();
+        let child_pk = PublicKey::<Secp256k1>::try_from(child_point)
+            .map_err(|_| ChainGangError::BadData("Invalid derived public key".to_string()))?;
+        let child_bytes = child_pk.to_sec1_bytes();
         let pk_vec = child_bytes.to_vec();
         assert!(pk_vec.len() == 33);
         let child_public_key: [u8; 33] = pk_vec[..].try_into().unwrap();
@@ -488,6 +491,34 @@ pub fn derive_extended_key(
     }
 
     Ok(key)
+}
+
+/// BIP-32 HMAC-SHA512 key for master extended key generation.
+pub const BIP32_MASTER_SEED_KEY: &[u8] = b"Bitcoin seed";
+
+/// Minimum BIP-32 seed length in bytes (128 bits).
+pub const MIN_BIP32_SEED_LENGTH: usize = 16;
+
+/// Derives a BIP-32 master extended private key from a seed (HMAC-SHA512).
+pub fn master_extended_key_from_seed(
+    network: Network,
+    seed: &[u8],
+) -> Result<ExtendedKey, ChainGangError> {
+    if seed.len() < MIN_BIP32_SEED_LENGTH {
+        return Err(ChainGangError::BadArgument(
+            "BIP-32 seed must be at least 16 bytes".to_string(),
+        ));
+    }
+    let mut mac = HmacSha512::new_from_slice(BIP32_MASTER_SEED_KEY)
+        .map_err(|_| ChainGangError::IllegalState("HMAC-SHA512 init failed".to_string()))?;
+    mac.update(seed);
+    let hmac = mac.finalize().into_bytes();
+    if !is_private_key_valid(&hmac[..32]) {
+        return Err(ChainGangError::BadData(
+            "BIP-32 master key invalid for seed".to_string(),
+        ));
+    }
+    ExtendedKey::new_private_key(network, 0, &[0; 4], 0, &hmac[32..], &hmac[..32])
 }
 
 /// Checks that a private key is in valid SECP256K1 range
@@ -713,28 +744,64 @@ mod tests {
     }
 
     #[test]
+    fn public_derivation_matches_private_extended_public_key() {
+        let m = master_extended_key_from_seed(
+            Network::BSV_Mainnet,
+            &hex::decode("000102030405060708090a0b0c0d0e0f").unwrap(),
+        )
+        .unwrap();
+        let hardened_child_pub = derive_extended_key(&m, "m/0H")
+            .unwrap()
+            .extended_public_key()
+            .unwrap();
+        let from_private = derive_extended_key(&m, "m/0h/1")
+            .unwrap()
+            .extended_public_key()
+            .unwrap();
+        let from_public = derive_extended_key(&hardened_child_pub, "M/1").unwrap();
+        assert_eq!(from_private, from_public);
+        assert_eq!(
+            from_public.encode(),
+            "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ"
+        );
+
+        let m2 = master_extended_key_from_seed(
+            Network::BSV_Mainnet,
+            &hex::decode(
+                "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let account_pub = derive_extended_key(&m2, "m/0")
+            .unwrap()
+            .extended_public_key()
+            .unwrap();
+        let from_private = derive_extended_key(&m2, "m/0/1")
+            .unwrap()
+            .extended_public_key()
+            .unwrap();
+        let from_public = derive_extended_key(&account_pub, "M/1").unwrap();
+        assert_eq!(from_private, from_public);
+    }
+
+    #[test]
+    fn master_from_seed_rejects_short_seed() {
+        assert!(master_extended_key_from_seed(Network::BSV_Mainnet, &[0u8; 8]).is_err());
+    }
+
+    #[test]
     fn encode_decode() {
-        let k = master_private_key("0123456789abcdef");
+        let k = master_private_key("0123456789abcdef0123456789abcdef");
         assert!(k == ExtendedKey::decode(&k.encode()).unwrap());
         let k = derive_extended_key(&k, "M/1/2/3/4/5").unwrap();
         assert!(k == ExtendedKey::decode(&k.encode()).unwrap());
     }
 
     fn master_private_key(seed: &str) -> ExtendedKey {
-        let seed = hex::decode(seed).unwrap();
-        let key = "Bitcoin seed".to_string();
-
-        let mut key = HmacSha512::new_from_slice(key.as_bytes()).expect("hmac512 error");
-        key.update(&seed);
-        let hmac = key.finalize().into_bytes();
-
-        ExtendedKey::new_private_key(
+        master_extended_key_from_seed(
             Network::BSV_Mainnet,
-            0,
-            &[0; 4],
-            0,
-            &hmac[32..],
-            &hmac[0..32],
+            &hex::decode(seed).unwrap(),
         )
         .unwrap()
     }

--- a/src/wallet/extended_key.rs
+++ b/src/wallet/extended_key.rs
@@ -21,6 +21,9 @@ const SECP256K1_CURVE_ORDER: [u8; 32] = [
 /// Index which begins the derived hardened keys
 pub const HARDENED_KEY: u32 = 2147483648;
 
+/// Error message when BIP-32 child derivation must skip to the next index.
+pub const INVALID_CHILD_KEY_MSG: &str = "Invalid key. Try next index.";
+
 /// "xpub" prefix for public extended keys on mainnet
 pub const MAINNET_PUBLIC_EXTENDED_KEY: u32 = 0x0488B21E;
 /// "xprv" prefix for private extended keys on mainnet
@@ -259,8 +262,28 @@ impl ExtendedKey {
         }
     }
 
-    /// Derives an extended child private key from an extended parent private key
+    /// Derives an extended child private key from an extended parent private key.
+    ///
+    /// If the derived key is invalid per BIP-32, increments the child index and retries.
     pub fn derive_private_key(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
+        let mut idx = index;
+        loop {
+            match self.try_derive_private_key_once(idx) {
+                Ok(key) => return Ok(key),
+                Err(ChainGangError::IllegalState(ref msg)) if msg == INVALID_CHILD_KEY_MSG => {
+                    if idx == u32::MAX {
+                        return Err(ChainGangError::BadData(
+                            "No valid BIP-32 child private key found".to_string(),
+                        ));
+                    }
+                    idx += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn try_derive_private_key_once(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
         if self.key_type()? == ExtendedKeyType::Public {
             let msg = "Cannot derive private key from public key";
             return Err(ChainGangError::BadData(msg.to_string()));
@@ -303,19 +326,13 @@ impl ExtendedKey {
         }
 
         if !is_private_key_valid(&hmac[..32]) {
-            let msg = "Invalid key. Try next index.".to_string();
-            return Err(ChainGangError::IllegalState(msg));
+            return Err(ChainGangError::IllegalState(INVALID_CHILD_KEY_MSG.to_string()));
         }
 
         let secp_child_secret_key = SecretKey::from_slice(&hmac[..32])?;
         let child_sk = *secp_child_secret_key.as_scalar_primitive();
         let private_sk = secp_par_secret_key.as_scalar_primitive();
-
-        //secp_child_secret_key.add_assign(private_key)?;
         let child_sk = child_sk.add(private_sk);
-
-        //let child_private_key =
-        //    unsafe { slice::from_raw_parts(secp_child_secret_key.as_ptr(), 32) };
         let child_private_key: [u8; 32] = child_sk.to_bytes().into();
 
         let child_chain_code = &hmac[32..];
@@ -331,8 +348,28 @@ impl ExtendedKey {
         )
     }
 
-    /// Derives an extended child public key from an extended parent public key
+    /// Derives an extended child public key from an extended parent public key.
+    ///
+    /// If the derived key is invalid per BIP-32, increments the child index and retries.
     pub fn derive_public_key(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
+        let mut idx = index;
+        loop {
+            match self.try_derive_public_key_once(idx) {
+                Ok(key) => return Ok(key),
+                Err(ChainGangError::IllegalState(ref msg)) if msg == INVALID_CHILD_KEY_MSG => {
+                    if idx == u32::MAX {
+                        return Err(ChainGangError::BadData(
+                            "No valid BIP-32 child public key found".to_string(),
+                        ));
+                    }
+                    idx += 1;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    fn try_derive_public_key_once(&self, index: u32) -> Result<ExtendedKey, ChainGangError> {
         if index >= HARDENED_KEY {
             return Err(ChainGangError::BadArgument(
                 "i cannot be hardened".to_string(),
@@ -361,8 +398,7 @@ impl ExtendedKey {
         }
 
         if !is_private_key_valid(&hmac[..32]) {
-            let msg = "Invalid key. Try next index.".to_string();
-            return Err(ChainGangError::IllegalState(msg));
+            return Err(ChainGangError::IllegalState(INVALID_CHILD_KEY_MSG.to_string()));
         }
 
         let secret_key = SecretKey::from_slice(&hmac[..32])?;
@@ -371,8 +407,9 @@ impl ExtendedKey {
             .map_err(|_| ChainGangError::BadData("Invalid parent public key".to_string()))?;
         let offset_pk = secret_key.public_key();
         let child_point = parent_pk.to_projective() + offset_pk.to_projective();
-        let child_pk = PublicKey::<Secp256k1>::try_from(child_point)
-            .map_err(|_| ChainGangError::BadData("Invalid derived public key".to_string()))?;
+        let child_pk = PublicKey::<Secp256k1>::try_from(child_point).map_err(|_| {
+            ChainGangError::IllegalState(INVALID_CHILD_KEY_MSG.to_string())
+        })?;
         let child_bytes = child_pk.to_sec1_bytes();
         let pk_vec = child_bytes.to_vec();
         assert!(pk_vec.len() == 33);

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -1,0 +1,177 @@
+//! BIP-32 hierarchical deterministic wallet helpers.
+
+use crate::network::Network;
+use crate::script::Script;
+use crate::util::ChainGangError;
+use crate::wallet::extended_key::{
+    derive_extended_key, master_extended_key_from_seed, ExtendedKey, ExtendedKeyType,
+};
+use crate::wallet::wallet::Wallet;
+
+/// BSV mainnet coin type per SLIP-44.
+pub const BSV_COIN_TYPE: u32 = 236;
+
+/// Builds a BIP-32 account path: `m/{account}'/{change}/{index}`.
+///
+/// `change` is `0` for external (receive) keys and `1` for internal (change) keys.
+pub fn bip32_path(account: u32, change: u32, index: u32) -> String {
+    format!("m/{}'/{}/{}", account, change, index)
+}
+
+/// Builds a BIP-44 style path: `m/44'/{coin_type}'/{account}'/{change}/{index}`.
+pub fn bip44_path(coin_type: u32, account: u32, external: bool, index: u32) -> String {
+    let change = if external { 0 } else { 1 };
+    format!("m/44'/{}'/{}'/{}/{}", coin_type, account, change, index)
+}
+
+/// HD wallet rooted at a BIP-32 master extended **private** key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HdWallet {
+    master: ExtendedKey,
+}
+
+impl HdWallet {
+    /// Creates an HD wallet from a master extended private key.
+    pub fn from_master(master: ExtendedKey) -> Result<Self, ChainGangError> {
+        if master.key_type()? != ExtendedKeyType::Private {
+            return Err(ChainGangError::BadArgument(
+                "HdWallet requires a master extended private key".to_string(),
+            ));
+        }
+        Ok(HdWallet { master })
+    }
+
+    /// Creates an HD wallet from a BIP-32 seed.
+    pub fn from_seed(network: Network, seed: &[u8]) -> Result<Self, ChainGangError> {
+        let master = master_extended_key_from_seed(network, seed)?;
+        Ok(HdWallet { master })
+    }
+
+    /// Master extended private key (`m`).
+    pub fn master(&self) -> ExtendedKey {
+        self.master
+    }
+
+    /// Network encoded in the master extended key.
+    pub fn network(&self) -> Result<Network, ChainGangError> {
+        self.master.network()
+    }
+
+    /// Derives an extended key along a BIP-32 path (`m/...` or `M/...`).
+    pub fn derive_path(&self, path: &str) -> Result<ExtendedKey, ChainGangError> {
+        derive_extended_key(&self.master, path)
+    }
+
+    /// Derives a signing [`Wallet`] at a private BIP-32 path.
+    pub fn wallet_at_path(&self, path: &str) -> Result<Wallet, ChainGangError> {
+        Wallet::from_extended_key(&self.derive_path(path)?)
+    }
+
+    /// P2PKH address at `m/{account}'/{change}/{index}`.
+    pub fn address_at(&self, account: u32, external: bool, index: u32) -> Result<String, ChainGangError> {
+        let change = if external { 0 } else { 1 };
+        self.wallet_at_path(&bip32_path(account, change, index))?.get_address()
+    }
+
+    /// Locking script at `m/{account}'/{change}/{index}`.
+    pub fn locking_script_at(
+        &self,
+        account: u32,
+        external: bool,
+        index: u32,
+    ) -> Result<Script, ChainGangError> {
+        let change = if external { 0 } else { 1 };
+        Ok(self
+            .wallet_at_path(&bip32_path(account, change, index))?
+            .get_locking_script())
+    }
+
+    /// P2PKH address at a BIP-44 path for the given coin type.
+    pub fn address_at_bip44(
+        &self,
+        coin_type: u32,
+        account: u32,
+        external: bool,
+        index: u32,
+    ) -> Result<String, ChainGangError> {
+        self.wallet_at_path(&bip44_path(coin_type, account, external, index))?.get_address()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messages::{
+        OutPoint, Tx, TxIn, TxOut, COINBASE_OUTPOINT_HASH, COINBASE_OUTPOINT_INDEX,
+    };
+    use crate::transaction::sighash::{SIGHASH_ALL, SIGHASH_FORKID};
+    use hex;
+
+    fn test_seed() -> Vec<u8> {
+        hex::decode("000102030405060708090a0b0c0d0e0f").unwrap()
+    }
+
+    #[test]
+    fn wallet_at_path_matches_extended_private_key() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let path = bip32_path(0, 0, 5);
+        let wallet = hd.wallet_at_path(&path).unwrap();
+        let key = hd.derive_path(&path).unwrap();
+        assert_eq!(wallet.public_key_serialize(), key.public_key().unwrap());
+    }
+
+    #[test]
+    fn bip44_path_derives_distinct_addresses() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let a0 = hd.address_at_bip44(BSV_COIN_TYPE, 0, true, 0).unwrap();
+        let a1 = hd.address_at_bip44(BSV_COIN_TYPE, 0, true, 1).unwrap();
+        assert_ne!(a0, a1);
+    }
+
+    #[test]
+    fn wallet_at_path_signs_p2pkh_spend() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let wallet = hd.wallet_at_path(&bip32_path(0, 0, 0)).unwrap();
+        let lock = wallet.get_locking_script();
+
+        let fund = Tx {
+            version: 1,
+            inputs: vec![TxIn {
+                prev_output: OutPoint {
+                    hash: COINBASE_OUTPOINT_HASH,
+                    index: COINBASE_OUTPOINT_INDEX,
+                },
+                unlock_script: Script::new(),
+                sequence: 0xffffffff,
+            }],
+            outputs: vec![TxOut {
+                satoshis: 10_000,
+                lock_script: lock,
+            }],
+            lock_time: 0,
+        };
+
+        let mut spend = Tx {
+            version: 1,
+            inputs: vec![TxIn {
+                prev_output: OutPoint {
+                    hash: fund.hash(),
+                    index: 0,
+                },
+                unlock_script: Script::new(),
+                sequence: 0xffffffff,
+            }],
+            outputs: vec![TxOut {
+                satoshis: 9_000,
+                lock_script: Script::new(),
+            }],
+            lock_time: 0,
+        };
+
+        let sighash_flags = SIGHASH_ALL | SIGHASH_FORKID;
+        wallet
+            .sign_tx_input(&fund, &mut spend, 0, sighash_flags)
+            .unwrap();
+        assert!(!spend.inputs[0].unlock_script.0.is_empty());
+    }
+}

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -6,6 +6,7 @@ use crate::util::ChainGangError;
 use crate::wallet::extended_key::{
     derive_extended_key, master_extended_key_from_seed, ExtendedKey, ExtendedKeyType,
 };
+use crate::wallet::mnemonic::mnemonic_to_seed_validated;
 use crate::wallet::wallet::Wallet;
 
 /// BSV mainnet coin type per SLIP-44.
@@ -45,6 +46,17 @@ impl HdWallet {
     pub fn from_seed(network: Network, seed: &[u8]) -> Result<Self, ChainGangError> {
         let master = master_extended_key_from_seed(network, seed)?;
         Ok(HdWallet { master })
+    }
+
+    /// Creates an HD wallet from a validated BIP-39 mnemonic (English word list).
+    pub fn from_mnemonic(
+        network: Network,
+        mnemonic: &str,
+        passphrase: &str,
+        word_list: &[String],
+    ) -> Result<Self, ChainGangError> {
+        let seed = mnemonic_to_seed_validated(mnemonic, passphrase, word_list)?;
+        Self::from_seed(network, &seed)
     }
 
     /// Master extended private key (`m`).
@@ -109,6 +121,17 @@ mod tests {
 
     fn test_seed() -> Vec<u8> {
         hex::decode("000102030405060708090a0b0c0d0e0f").unwrap()
+    }
+
+    #[test]
+    fn from_mnemonic_matches_from_seed() {
+        let wordlist = crate::wallet::load_wordlist(crate::wallet::Wordlist::English);
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let seed = crate::wallet::mnemonic_to_seed_validated(mnemonic, "", &wordlist).unwrap();
+        let from_seed = HdWallet::from_seed(Network::BSV_Mainnet, &seed).unwrap();
+        let from_mnemonic =
+            HdWallet::from_mnemonic(Network::BSV_Mainnet, mnemonic, "", &wordlist).unwrap();
+        assert_eq!(from_seed.master(), from_mnemonic.master());
     }
 
     #[test]

--- a/src/wallet/hd_wallet.rs
+++ b/src/wallet/hd_wallet.rs
@@ -108,6 +108,23 @@ impl HdWallet {
     ) -> Result<String, ChainGangError> {
         self.wallet_at_path(&bip44_path(coin_type, account, external, index))?.get_address()
     }
+
+    /// Scans external receive addresses for `account` until `gap_limit` consecutive unused indices.
+    pub fn scan_external_addresses<F>(
+        &self,
+        account: u32,
+        gap_limit: u32,
+        is_used: F,
+    ) -> Result<Vec<String>, ChainGangError>
+    where
+        F: Fn(&str) -> bool,
+    {
+        crate::wallet::hd_watch_wallet::scan_address_indices(
+            |i| self.address_at(account, true, i),
+            gap_limit,
+            is_used,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/wallet/hd_watch_wallet.rs
+++ b/src/wallet/hd_watch_wallet.rs
@@ -1,0 +1,191 @@
+//! BIP-32 watch-only (xpub) wallet helpers.
+
+use crate::network::Network;
+use crate::script::Script;
+use crate::util::ChainGangError;
+use crate::wallet::extended_key::{
+    derive_extended_key, ExtendedKey, ExtendedKeyType,
+};
+use crate::wallet::wallet::{p2pkh_script, public_key_to_address};
+
+/// Default BIP-44 gap limit for address discovery.
+pub const DEFAULT_GAP_LIMIT: u32 = 20;
+
+/// Builds a relative BIP-32 path from an account-level extended public key: `M/{change}/{index}`.
+pub fn watch_bip32_path(change: u32, index: u32) -> String {
+    format!("M/{}/{}", change, index)
+}
+
+/// Builds a relative BIP-44 path from an account-level extended public key.
+pub fn watch_bip44_path(external: bool, index: u32) -> String {
+    let change = if external { 0 } else { 1 };
+    watch_bip32_path(change, index)
+}
+
+/// Watch-only HD wallet rooted at an extended **public** key (typically account-level `xpub`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HdWatchWallet {
+    master: ExtendedKey,
+}
+
+impl HdWatchWallet {
+    /// Creates a watch-only wallet from an encoded extended public key (`xpub` / `tpub`).
+    pub fn from_xpub(xpub: &str) -> Result<Self, ChainGangError> {
+        Self::from_master(ExtendedKey::decode(xpub)?)
+    }
+
+    /// Creates a watch-only wallet from a master extended public key.
+    pub fn from_master(master: ExtendedKey) -> Result<Self, ChainGangError> {
+        if master.key_type()? != ExtendedKeyType::Public {
+            return Err(ChainGangError::BadArgument(
+                "HdWatchWallet requires an extended public key".to_string(),
+            ));
+        }
+        Ok(HdWatchWallet { master })
+    }
+
+    pub fn master(&self) -> ExtendedKey {
+        self.master
+    }
+
+    pub fn network(&self) -> Result<Network, ChainGangError> {
+        self.master.network()
+    }
+
+    /// Derives an extended public key along a BIP-32 path (`M/...`).
+    pub fn derive_path(&self, path: &str) -> Result<ExtendedKey, ChainGangError> {
+        derive_extended_key(&self.master, path)
+    }
+
+    /// Compressed public key bytes at `path`.
+    pub fn public_key_at_path(&self, path: &str) -> Result<Vec<u8>, ChainGangError> {
+        Ok(self.derive_path(path)?.public_key()?.to_vec())
+    }
+
+    /// P2PKH address at `path`.
+    pub fn address_at_path(&self, path: &str) -> Result<String, ChainGangError> {
+        let pk = self.public_key_at_path(path)?;
+        public_key_to_address(&pk, self.network()?)
+    }
+
+    /// P2PKH locking script at `path`.
+    pub fn locking_script_at_path(&self, path: &str) -> Result<Script, ChainGangError> {
+        let pk = self.public_key_at_path(path)?;
+        Ok(p2pkh_script(&crate::util::hash160(&pk).0))
+    }
+
+    /// P2PKH address at `M/{change}/{index}` relative to an account-level `xpub`.
+    pub fn address_at(&self, external: bool, index: u32) -> Result<String, ChainGangError> {
+        let change = if external { 0 } else { 1 };
+        self.address_at_path(&watch_bip32_path(change, index))
+    }
+
+    /// P2PKH address at a relative BIP-44 receive/change chain index.
+    pub fn address_at_bip44(&self, external: bool, index: u32) -> Result<String, ChainGangError> {
+        self.address_at_path(&watch_bip44_path(external, index))
+    }
+
+    /// Scans external or change chain indices until `gap_limit` consecutive unused addresses.
+    pub fn scan_addresses<F>(
+        &self,
+        external: bool,
+        gap_limit: u32,
+        is_used: F,
+    ) -> Result<Vec<String>, ChainGangError>
+    where
+        F: Fn(&str) -> bool,
+    {
+        scan_address_indices(|i| self.address_at(external, i), gap_limit, is_used)
+    }
+}
+
+/// Scans address indices until `gap_limit` consecutive unused addresses.
+pub fn scan_address_indices<G, H>(
+    address_at: G,
+    gap_limit: u32,
+    is_used: H,
+) -> Result<Vec<String>, ChainGangError>
+where
+    G: Fn(u32) -> Result<String, ChainGangError>,
+    H: Fn(&str) -> bool,
+{
+    let mut used_addresses = Vec::new();
+    let mut gap = 0u32;
+    let mut index = 0u32;
+
+    while gap < gap_limit {
+        let addr = address_at(index)?;
+        if is_used(&addr) {
+            used_addresses.push(addr);
+            gap = 0;
+        } else {
+            gap += 1;
+        }
+        index += 1;
+    }
+
+    Ok(used_addresses)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::hd_wallet::{bip32_path, HdWallet};
+    use hex;
+
+    fn test_seed() -> Vec<u8> {
+        hex::decode("000102030405060708090a0b0c0d0e0f").unwrap()
+    }
+
+    #[test]
+    fn watch_wallet_matches_private_derivation() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let account_xpub = hd
+            .derive_path("m/0'")
+            .unwrap()
+            .extended_public_key()
+            .unwrap()
+            .encode();
+        let watch = HdWatchWallet::from_xpub(&account_xpub).unwrap();
+
+        let priv_addr = hd.address_at(0, true, 5).unwrap();
+        let watch_addr = watch.address_at(true, 5).unwrap();
+        assert_eq!(priv_addr, watch_addr);
+    }
+
+    #[test]
+    fn watch_path_matches_full_bip32_path() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let account_xpub = hd
+            .derive_path("m/0'")
+            .unwrap()
+            .extended_public_key()
+            .unwrap()
+            .encode();
+        let watch = HdWatchWallet::from_xpub(&account_xpub).unwrap();
+
+        let path = bip32_path(0, 0, 3);
+        let full_addr = hd.wallet_at_path(&path).unwrap().get_address().unwrap();
+        let watch_addr = watch.address_at_path(&watch_bip32_path(0, 3)).unwrap();
+        assert_eq!(full_addr, watch_addr);
+    }
+
+    #[test]
+    fn gap_scan_collects_used_addresses() {
+        let hd = HdWallet::from_seed(Network::BSV_Mainnet, &test_seed()).unwrap();
+        let account_xpub = hd
+            .derive_path("m/0'")
+            .unwrap()
+            .extended_public_key()
+            .unwrap()
+            .encode();
+        let watch = HdWatchWallet::from_xpub(&account_xpub).unwrap();
+
+        let a0 = watch.address_at(true, 0).unwrap();
+        let a2 = watch.address_at(true, 2).unwrap();
+        let used = watch
+            .scan_addresses(true, 2, |addr| addr == &a0 || addr == &a2)
+            .unwrap();
+        assert_eq!(used, vec![a0, a2]);
+    }
+}

--- a/src/wallet/mnemonic.rs
+++ b/src/wallet/mnemonic.rs
@@ -1,9 +1,51 @@
 //! Functions to convert data to and from mnemonic words
 
 use crate::util::{Bits, ChainGangError};
-use sha2::{Digest, Sha256};
-
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use sha2::{Digest, Sha256, Sha512};
 use std::str;
+
+type HmacSha512 = Hmac<Sha512>;
+
+/// PBKDF2 iteration count for BIP-39 seed generation.
+pub const BIP39_PBKDF2_ITERATIONS: u32 = 2048;
+
+/// PBKDF2 salt prefix for BIP-39 (`mnemonic` + passphrase).
+pub const BIP39_SALT_PREFIX: &str = "mnemonic";
+
+/// Splits a mnemonic phrase into normalized words.
+pub fn mnemonic_parse(mnemonic: &str) -> Vec<String> {
+    mnemonic
+        .split_whitespace()
+        .map(|word| word.to_string())
+        .collect()
+}
+
+/// Derives a BIP-39 seed (64 bytes) from a mnemonic sentence and optional passphrase.
+pub fn mnemonic_to_seed(mnemonic: &str, passphrase: &str) -> [u8; 64] {
+    let salt = format!("{}{}", BIP39_SALT_PREFIX, passphrase);
+    let mut seed = [0u8; 64];
+    pbkdf2::<HmacSha512>(
+        mnemonic.as_bytes(),
+        salt.as_bytes(),
+        BIP39_PBKDF2_ITERATIONS,
+        &mut seed,
+    )
+    .expect("HMAC can take key of any size");
+    seed
+}
+
+/// Validates a mnemonic against a word list and returns the BIP-39 seed.
+pub fn mnemonic_to_seed_validated(
+    mnemonic: &str,
+    passphrase: &str,
+    word_list: &[String],
+) -> Result<[u8; 64], ChainGangError> {
+    let words = mnemonic_parse(mnemonic);
+    mnemonic_decode(&words, word_list)?;
+    Ok(mnemonic_to_seed(mnemonic, passphrase))
+}
 
 /// Wordlist language
 pub enum Wordlist {
@@ -87,6 +129,19 @@ pub fn mnemonic_decode(
 mod tests {
     use super::*;
     use hex;
+
+    #[test]
+    fn mnemonic_to_seed_vector() {
+        let wordlist = load_wordlist(Wordlist::English);
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        mnemonic_decode(&mnemonic_parse(mnemonic), &wordlist).unwrap();
+        let seed = mnemonic_to_seed(mnemonic, "");
+        let expected = hex::decode(
+            "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4",
+        )
+        .unwrap();
+        assert_eq!(seed.as_slice(), expected.as_slice());
+    }
 
     #[test]
     fn wordlists() {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2,6 +2,7 @@
 
 mod extended_key;
 mod hd_wallet;
+mod hd_watch_wallet;
 mod mnemonic;
 
 pub mod base58_checksum;
@@ -10,10 +11,14 @@ pub mod wallet;
 
 pub use self::extended_key::{
     derive_extended_key, master_extended_key_from_seed, ExtendedKey, ExtendedKeyType,
-    BIP32_MASTER_SEED_KEY, HARDENED_KEY, MIN_BIP32_SEED_LENGTH, MAINNET_PRIVATE_EXTENDED_KEY,
-    MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY, TESTNET_PUBLIC_EXTENDED_KEY,
+    BIP32_MASTER_SEED_KEY, HARDENED_KEY, INVALID_CHILD_KEY_MSG, MIN_BIP32_SEED_LENGTH,
+    MAINNET_PRIVATE_EXTENDED_KEY, MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY,
+    TESTNET_PUBLIC_EXTENDED_KEY,
 };
 pub use self::hd_wallet::{bip32_path, bip44_path, BSV_COIN_TYPE, HdWallet};
+pub use self::hd_watch_wallet::{
+    scan_address_indices, watch_bip32_path, watch_bip44_path, DEFAULT_GAP_LIMIT, HdWatchWallet,
+};
 pub use self::mnemonic::{
     load_wordlist, mnemonic_decode, mnemonic_encode, mnemonic_parse, mnemonic_to_seed,
     mnemonic_to_seed_validated, Wordlist, BIP39_PBKDF2_ITERATIONS, BIP39_SALT_PREFIX,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -14,7 +14,10 @@ pub use self::extended_key::{
     MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY, TESTNET_PUBLIC_EXTENDED_KEY,
 };
 pub use self::hd_wallet::{bip32_path, bip44_path, BSV_COIN_TYPE, HdWallet};
-pub use self::mnemonic::{load_wordlist, mnemonic_decode, mnemonic_encode, Wordlist};
+pub use self::mnemonic::{
+    load_wordlist, mnemonic_decode, mnemonic_encode, mnemonic_parse, mnemonic_to_seed,
+    mnemonic_to_seed_validated, Wordlist, BIP39_PBKDF2_ITERATIONS, BIP39_SALT_PREFIX,
+};
 
 pub use self::wallet::{
     create_sighash, create_sighash_checksig_index, public_key_to_address, Wallet, MAIN_PRIVATE_KEY,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1,6 +1,7 @@
 //! Wallet and key management
 
 mod extended_key;
+mod hd_wallet;
 mod mnemonic;
 
 pub mod base58_checksum;
@@ -12,6 +13,7 @@ pub use self::extended_key::{
     BIP32_MASTER_SEED_KEY, HARDENED_KEY, MIN_BIP32_SEED_LENGTH, MAINNET_PRIVATE_EXTENDED_KEY,
     MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY, TESTNET_PUBLIC_EXTENDED_KEY,
 };
+pub use self::hd_wallet::{bip32_path, bip44_path, BSV_COIN_TYPE, HdWallet};
 pub use self::mnemonic::{load_wordlist, mnemonic_decode, mnemonic_encode, Wordlist};
 
 pub use self::wallet::{

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -8,7 +8,8 @@ pub mod base58_checksum;
 pub mod wallet;
 
 pub use self::extended_key::{
-    derive_extended_key, ExtendedKey, ExtendedKeyType, HARDENED_KEY, MAINNET_PRIVATE_EXTENDED_KEY,
+    derive_extended_key, master_extended_key_from_seed, ExtendedKey, ExtendedKeyType,
+    BIP32_MASTER_SEED_KEY, HARDENED_KEY, MIN_BIP32_SEED_LENGTH, MAINNET_PRIVATE_EXTENDED_KEY,
     MAINNET_PUBLIC_EXTENDED_KEY, TESTNET_PRIVATE_EXTENDED_KEY, TESTNET_PUBLIC_EXTENDED_KEY,
 };
 pub use self::mnemonic::{load_wordlist, mnemonic_decode, mnemonic_encode, Wordlist};

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -154,6 +154,24 @@ impl Wallet {
             network,
         }
     }
+
+    /// Builds a signing wallet from an extended **private** key (leaf or intermediate).
+    pub fn from_extended_key(key: &crate::wallet::extended_key::ExtendedKey) -> Result<Self, ChainGangError> {
+        if key.key_type()? != crate::wallet::extended_key::ExtendedKeyType::Private {
+            return Err(ChainGangError::BadArgument(
+                "Cannot build Wallet from an extended public key".to_string(),
+            ));
+        }
+        let network = key.network()?;
+        let private_key = SigningKey::from_slice(&key.private_key()?)?;
+        let public_key = *private_key.verifying_key();
+        Ok(Wallet {
+            private_key,
+            public_key,
+            network,
+        })
+    }
+
     pub fn get_address(&self) -> Result<String, ChainGangError> {
         public_key_to_address(&self.public_key_serialize(), self.network)
     }


### PR DESCRIPTION
## Summary
- Bump `chain-gang` / `tx-engine` to **v0.9.0** (`Cargo.toml`, `docs/Releases.md`, `README.md`)
- Includes the full BIP-32 stack (#106–#110): CKD' fix, `HdWallet`, mnemonic/Python bindings, watch-only `xpub`, gap scan, documentation
- Includes dependency updates from #111 (`pyo3` 0.28.2, `cryptography` 49.0.0, `log`, `reqwest`, `regex`, `typenum`)

## Merge options
- **Single release:** merge this PR to `main` (supersedes the stacked BIP-32 PRs and #111)
- **Stacked:** merge #106 → #107 → … → #110 and #111 first, then cherry-pick or merge only the version commit from this branch

## After merge (per `docs/Development.md`)
```bash
git tag -a v0.9.0 -m "BIP-32 HD wallets, watch-only xpub, dependency updates"
git push origin v0.9.0
```

## Test plan
- [x] `cargo test --all-features`


Made with [Cursor](https://cursor.com)