### PR TITLE
Upgrade k256 to 0.14-rc and rand to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ url = "2.5.8"
 murmur3 = "0.5.2"
 num-bigint = "0.4.6"
 num-traits = "0.2"
-rand = "0.8.6"  # Don't bump this unless k256 is updated 
+rand = "0.9.2"
 ripemd = "0.1.3"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
-k256 = { version = "0.13.4", features = ["alloc", "arithmetic", "digest", "ecdsa", "once_cell", "pkcs8", "precomputed-tables", "schnorr",
+k256 = { version = "0.14.0-rc.12", features = ["alloc", "arithmetic", "digest", "ecdsa", "getrandom", "pkcs8", "precomputed-tables", "schnorr",
     "sha2", "sha256", "signature", "std"]}
 snowflake = "1.3"
 hmac = "0.12.1"
@@ -46,7 +46,6 @@ async-trait = { version = "0.1.89", optional = true }
 pyo3 = { version = "0.28.2", optional = true }
 regex = "1.12.4"
 lazy_static = "1.5.0"
-rand_core = "0.9.5"
 typenum = "1.20.1"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ num-bigint = "0.4.6"
 num-traits = "0.2"
 rand = "0.9.2"
 ripemd = "0.1.3"
-sha1 = "0.10.6"
-sha2 = "0.10.9"
+sha1 = "0.11.0"
+sha2 = "0.11.0"
 k256 = { version = "0.14.0-rc.12", features = ["alloc", "arithmetic", "digest", "ecdsa", "getrandom", "pkcs8", "precomputed-tables", "schnorr",
     "sha2", "sha256", "signature", "std"]}
 snowflake = "1.3"
-hmac = "0.12.1"
+hmac = "0.13.0"
 base58 = "0.2.0"
 pbkdf2 = { version = "0.13.0", features = ["hmac", "sha2"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ murmur3 = "0.5.2"
 num-bigint = "0.4.6"
 num-traits = "0.2"
 rand = "0.9.2"
-ripemd = "0.1.3"
+ripemd = "0.2.0"
 sha1 = "0.11.0"
 sha2 = "0.11.0"
 k256 = { version = "0.14.0-rc.12", features = ["alloc", "arithmetic", "digest", "ecdsa", "getrandom", "pkcs8", "precomputed-tables", "schnorr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ k256 = { version = "0.14.0-rc.12", features = ["alloc", "arithmetic", "digest", 
 snowflake = "1.3"
 hmac = "0.12.1"
 base58 = "0.2.0"
-pbkdf2 = "0.12.2"
+pbkdf2 = { version = "0.13.0", features = ["hmac", "sha2"] }
 
 # Used by the interface feature
 serde = { version = "1.0.228", features = ["derive"], optional = true }

--- a/src/network/seed_iter.rs
+++ b/src/network/seed_iter.rs
@@ -1,5 +1,5 @@
 use dns_lookup::lookup_host;
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use std::net::IpAddr;
 
 /// Iterates through DNS seeds semi-randomly
@@ -23,7 +23,7 @@ impl SeedIter {
             nodes: Vec::new(),
             seed_index: 0,
             node_index: 0,
-            random_offset: thread_rng().gen_range(0..100),
+            random_offset: rng().random_range(0..100),
         }
     }
 }

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -20,9 +20,7 @@ use pyo3::{
 };
 use std::ffi::CString;
 
-use hmac::Hmac;
-use pbkdf2::pbkdf2;
-use sha2::Sha256;
+use pbkdf2::{hmac::Hmac, pbkdf2, sha2::Sha256};
 use std::num::NonZeroU32;
 
 /// Decode a compressed WIF private key to 32 raw bytes.
@@ -51,7 +49,7 @@ pub fn generate_wif(password: &str, nonce: &str, network: &str) -> String {
     let salt_bytes = nonce.as_bytes();
     let iterations = NonZeroU32::new(100_000).unwrap();
     let mut dk = [0u8; 32]; // 256-bit key
-    pbkdf2::<Hmac<Sha256>>(pw_bytes, salt_bytes, iterations.into(), &mut dk)
+    pbkdf2::<Hmac<Sha256>>(pw_bytes, salt_bytes, iterations.get(), &mut dk)
         .expect("HMAC can be initialized with any key length");
 
     // Choose prefix bytes based on network (mainnet or testnet)

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -20,7 +20,9 @@ use pyo3::{
 };
 use std::ffi::CString;
 
-use pbkdf2::{hmac::Hmac, pbkdf2, sha2::Sha256};
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use sha2::Sha256;
 use std::num::NonZeroU32;
 
 /// Decode a compressed WIF private key to 32 raw bytes.

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -12,7 +12,7 @@ use crate::{
         wallet::{wif_to_network_and_private_key, Wallet, MAIN_PRIVATE_KEY, TEST_PRIVATE_KEY},
     },
 };
-use k256::ecdsa::SigningKey;
+use k256::{ecdsa::SigningKey, elliptic_curve::Generate};
 use num_bigint::{BigInt, Sign};
 use pyo3::{
     prelude::*,
@@ -22,9 +22,6 @@ use std::ffi::CString;
 
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
-
-use rand::rngs::OsRng;
-
 use sha2::Sha256;
 use std::num::NonZeroU32;
 
@@ -277,7 +274,7 @@ impl PyWallet {
     #[classmethod]
     fn generate_keypair(_cls: &Bound<'_, PyType>, network: &str) -> PyResult<Self> {
         if let Some(netwrk) = str_to_network(network) {
-            let private_key = SigningKey::random(&mut OsRng);
+            let private_key = SigningKey::generate();
             let public_key = *private_key.verifying_key();
             let wallet = Wallet::new(private_key, public_key, netwrk);
             Ok(PyWallet { wallet })

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -258,7 +258,7 @@ impl Checker for TransactionChecker<'_> {
         let mut signature = Signature::from_der(der_sig)?;
         if self.chronicle_script_version() > 1 {
             // Chronicle lifts the low-S rule; normalize so k256 accepts high-S encodings.
-            signature = signature.normalize_s().unwrap_or(signature);
+            signature = signature.normalize_s();
         }
         let message = sig_hash.0;
         let verifying_key: VerifyingKey = VerifyingKey::from_sec1_bytes(pubkey)?;

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -48,7 +48,7 @@ pub fn uses_low_s_signing(sighash_type: u8) -> bool {
 /// Applies low-S normalization policy and appends the sighash type byte.
 fn encode_signature(signature: Signature, sighash_type: u8) -> Vec<u8> {
     let signature = if uses_low_s_signing(sighash_type) {
-        signature.normalize_s().unwrap_or(signature)
+        signature.normalize_s()
     } else {
         signature
     };
@@ -80,14 +80,12 @@ mod tests {
 
     fn signature_has_high_s(der: &[u8]) -> bool {
         let sig = Signature::from_der(der).unwrap();
-        sig.normalize_s()
-            .map(|normalized| normalized != sig)
-            .unwrap_or(false)
+        sig.normalize_s() != sig
     }
 
     fn flip_der_to_high_s(der: &[u8]) -> Vec<u8> {
         let sig = Signature::from_der(der).unwrap();
-        let low_s = sig.normalize_s().unwrap_or(sig);
+        let low_s = sig.normalize_s();
         assert!(
             !signature_has_high_s(low_s.to_der().as_bytes()),
             "expected low-S input for flip helper"
@@ -160,7 +158,7 @@ mod tests {
         let raw: Signature = signing_key.sign_prehash(&sighash.0).unwrap();
         let high_s =
             Signature::from_der(flip_der_to_high_s(raw.to_der().as_bytes()).as_slice()).unwrap();
-        let normalized = high_s.normalize_s().unwrap();
+        let normalized = high_s.normalize_s();
         assert_eq!(normalized, raw);
         assert!(
             signing_key

--- a/src/wallet/extended_key.rs
+++ b/src/wallet/extended_key.rs
@@ -330,8 +330,8 @@ impl ExtendedKey {
         }
 
         let secp_child_secret_key = SecretKey::from_slice(&hmac[..32])?;
-        let child_sk = *secp_child_secret_key.as_scalar_primitive();
-        let private_sk = secp_par_secret_key.as_scalar_primitive();
+        let child_sk = *secp_child_secret_key.as_scalar_value();
+        let private_sk = secp_par_secret_key.as_scalar_value();
         let child_sk = child_sk.add(private_sk);
         let child_private_key: [u8; 32] = child_sk.to_bytes().into();
 

--- a/src/wallet/extended_key.rs
+++ b/src/wallet/extended_key.rs
@@ -1,7 +1,7 @@
 use crate::network::Network;
 use crate::util::{hash160, sha256d, ChainGangError, Serializable};
 use byteorder::{BigEndian, WriteBytesExt};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha512;
 
 use base58::{FromBase58, ToBase58};

--- a/src/wallet/mnemonic.rs
+++ b/src/wallet/mnemonic.rs
@@ -1,9 +1,7 @@
 //! Functions to convert data to and from mnemonic words
 
 use crate::util::{Bits, ChainGangError};
-use hmac::Hmac;
-use pbkdf2::pbkdf2;
-use sha2::{Digest, Sha256, Sha512};
+use pbkdf2::{hmac::Hmac, pbkdf2, sha2::{Digest, Sha256, Sha512}};
 use std::str;
 
 type HmacSha512 = Hmac<Sha512>;

--- a/src/wallet/mnemonic.rs
+++ b/src/wallet/mnemonic.rs
@@ -1,7 +1,9 @@
 //! Functions to convert data to and from mnemonic words
 
 use crate::util::{Bits, ChainGangError};
-use pbkdf2::{hmac::Hmac, pbkdf2, sha2::{Digest, Sha256, Sha512}};
+use hmac::Hmac;
+use pbkdf2::pbkdf2;
+use sha2::{Digest, Sha256, Sha512};
 use std::str;
 
 type HmacSha512 = Hmac<Sha512>;


### PR DESCRIPTION
Restores #114 without the PyO3 bump (that stays in #113).

## Summary
- Bump `k256` to `0.14.0-rc.12` and `rand` to `0.9.2`
- Bump `pbkdf2` to `0.13.0`, `sha1`/`sha2` to `0.11.0`, `hmac` to `0.13.0`, `ripemd` to `0.2.0`
- Drop removed `once_cell` k256 feature; add `getrandom` for `SigningKey::generate()`
- Remove unused direct `rand_core` dependency
- Adapt call sites for k256 0.14 API changes: `as_scalar_value`, infallible `normalize_s()`, and `Generate` for key generation
- Update rand 0.9 deprecations in `seed_iter` (`rng`, `random_range`)
- Import `KeyInit` for BIP-32 HMAC-SHA512

## Notes
- k256 0.14.0-rc.12 MSRV is Rust 1.85+
- PyO3 remains at 0.28.2 on this branch

## Test plan
- [x] `cargo test --all-features` (192 tests pass)
- [ ] CI green on push


Made with [Cursor](https://cursor.com)