### PR TITLE
Release 0.9.1: abi3 wheels (3.11–3.14+) and pyo3 0.29 security bump

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,13 +16,11 @@ on:
   workflow_dispatch:
 
 env:
-  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
-  UNSAFE_PYO3_BUILD_FREE_THREADED: 1
   RUSTFLAGS: -A deprecated # Allow deprecated warnings, we are awaiting an updated k256 crate
 
-# When these env vars are removed some of the platforms can be enabled
-# below. 
-# They have had to be disabled as they didn't read these env vars.
+# Wheels are built against the stable ABI (pyo3 abi3-py311), so a single
+# cp311-abi3 wheel per platform covers Python 3.11 through 3.14 and beyond.
+# No --find-interpreter and no per-version matrix are needed.
 
 permissions:
   contents: read
@@ -50,12 +48,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.11'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter 3.11
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -78,13 +76,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.11'
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter 3.11
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -106,12 +104,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.11'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter 3.11
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,10 @@ async-mutex = { version = "1.4.1", optional = true }
 async-trait = { version = "0.1.89", optional = true }
 
 # For python feature
-pyo3 = { version = "0.28.2", optional = true }
+# abi3-py311 builds against the stable ABI: one wheel (cp311-abi3) works on
+# 3.11, 3.12, 3.13, 3.14 and every future CPython, so no per-version matrix
+# and no missing-version gaps. Floor matches `requires-python` in pyproject.toml.
+pyo3 = { version = "0.28.2", optional = true, features = ["abi3-py311"] }
 regex = "1.12.4"
 lazy_static = "1.5.0"
 typenum = "1.20.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-gang"
-version = "0.9.0"
+version = "0.9.1"
 description = "This is a library that enables monitoring of multiple blockchains (BTC, BCH, BSV)."
 # repository = "https://github.com/brentongunning/rust-sv"
 authors = ["Arthur Gordon <a.gordon@nchain.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ async-trait = { version = "0.1.89", optional = true }
 # abi3-py311 builds against the stable ABI: one wheel (cp311-abi3) works on
 # 3.11, 3.12, 3.13, 3.14 and every future CPython, so no per-version matrix
 # and no missing-version gaps. Floor matches `requires-python` in pyproject.toml.
-pyo3 = { version = "0.28.2", optional = true, features = ["abi3-py311"] }
+pyo3 = { version = "0.29.0", optional = true, features = ["abi3-py311"] }
 regex = "1.12.4"
 lazy_static = "1.5.0"
 typenum = "1.20.1"


### PR DESCRIPTION
## Problem

Two things, both rooted in how the `tx-engine` extension is built:

1. **Missing cp314 wheel.** `tx-engine` published version-specific wheels (`cp311`, `cp312`, …). On Linux, `maturin-action` builds inside its own manylinux container and `--find-interpreter` scans the Pythons *in that container* — setup-python's version is ignored there — so cp314 was silently never produced. That missing wheel blocks downstream consumers from bumping to Python 3.14.
2. **Two open Dependabot security alerts on `pyo3`** (both fixed in 0.29.0):
   - `GHSA-36hh-v3qg-5jq4` (**high**): out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators.
   - `GHSA-chgr-c6px-7xpp` (medium): missing `Sync` bound on `PyCFunction::new_closure` closures.

## Fix

- **abi3 build.** `pyo3` now uses `features = ["abi3-py311"]`, so a single `cp311-abi3` wheel per platform installs on 3.11, 3.12, 3.13, **3.14**, and every future CPython — no per-version matrix, no manylinux-freshness gap.
- **CI.yml.** Removed the `PYO3_USE_ABI3_FORWARD_COMPATIBILITY` half-measure and `UNSAFE_PYO3_BUILD_FREE_THREADED` flag; replaced `--find-interpreter` with `--interpreter 3.11` and set setup-python to 3.11 across linux/windows/macos.
- **pyo3 0.28 → 0.29.** Clears both security alerts. No source changes were needed for the API change.
- **Version 0.9.0 → 0.9.1.** Cuts a fresh release so the patched abi3 wheels actually publish (v0.9.0 already exists on PyPI; the release job uses `--skip-existing`).

## Verification

- `cargo build --release --features python --no-default-features` — clean on pyo3 0.29.0, builds as `v0.9.1`.
- `maturin build --release` → `tx_engine-0.9.1-cp311-abi3-…whl`; installed into a **Python 3.14** venv.
- Full Python suite: **208 tests pass** on CPython 3.14.

## Release

Merging this lands version `0.9.1` on `main`. Tag `v0.9.1` to trigger the CI release job, which builds the abi3 wheels + sdist and publishes to PyPI.

## Tradeoff

abi3 is incompatible with **free-threaded** CPython (3.13t/3.14t), hence dropping `UNSAFE_PYO3_BUILD_FREE_THREADED`. Classifiers and `requires-python` target standard CPython only, so this matches intent. A separate non-abi3 matrix job can be added if free-threaded wheels are ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)