### PR TITLE
Add Dependabot config for weekly cargo version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to schedule **weekly cargo version-update PRs**.

- `package-ecosystem: cargo`, weekly schedule.
- Groups **minor/patch** bumps into a single PR (`cargo-minor-patch`) to cut noise; **major** bumps still arrive as individual PRs for closer review.
- `open-pull-requests-limit: 10`, `deps` commit-message prefix.

## Why

The repo had no `dependabot.yml`, so there were no scheduled dependency updates. Combined with the now-enabled **automated security fixes** (which cover advisories on demand), this keeps the Rust dependency tree current proactively.

## Note

This only configures the **cargo** ecosystem as requested. `github-actions` and `pip` (the pyproject deps) could be added later as separate `updates:` entries if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)