### PR TITLE
Remove unused db-key dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ dns-lookup = "3.0.1"
 hex = "0.4.3"
 linked-hash-map = "0.5"
 log = { version = "0.4.32", features = ["max_level_trace", "release_max_level_warn"] }
-db-key = "0.0.5"  # this is a non-trival update
 thiserror = "2.0.18"
 url = "2.5.8"
 

--- a/src/util/hash256.rs
+++ b/src/util/hash256.rs
@@ -7,8 +7,6 @@ use std::{
     io::{Read, Write},
 };
 
-use db_key::Key;
-
 /// 256-bit hash for blocks and transactions
 ///
 /// It is interpreted as a single little-endian number for display.
@@ -85,20 +83,6 @@ impl PartialOrd for Hash256 {
 impl fmt::Debug for Hash256 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.encode())
-    }
-}
-
-// For use in LevelDB database
-impl Key for Hash256 {
-    fn from_u8(key: &[u8]) -> Hash256 {
-        assert!(key.len() == 32);
-        let mut bytes = [0; 32];
-        bytes.clone_from_slice(key);
-        Hash256(bytes)
-    }
-
-    fn as_slice<T, F: Fn(&[u8]) -> T>(&self, f: F) -> T {
-        f(&self.0)
     }
 }
 


### PR DESCRIPTION
## What

Removes the `db-key` dependency and the dead `impl Key for Hash256` it existed for.

- `Cargo.toml` — drop `db-key = "0.0.5"`
- `src/util/hash256.rs` — remove `use db_key::Key;` and the `impl Key for Hash256` block (`from_u8` / `as_slice`)

## Why

The trait impl was commented *"For use in LevelDB database"*, but **nothing in the crate uses LevelDB or that impl** — there's no `Database`/`leveldb` code anywhere in `src`. It was vestigial weight inherited from the rust-sv fork.

Removing it also **retires the breaking Dependabot bump [#118](https://github.com/nchain-innovation/chain-gang/pull/118)** (db-key 0.0.5 → 0.1.0), which only failed CI because it tried to adapt this dead code to db-key 0.1.0's redesigned `Key` trait. [#118](https://github.com/nchain-innovation/chain-gang/pull/118) should be closed as superseded.

## Verification

- `cargo build --release` — clean; `db-key` no longer appears in `Cargo.lock`.
- `cargo test --release` — **184 lib tests + 10 doctests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)