### PR TITLE
CI: disable cargo HTTP/2 multiplexing to avoid crates.io fetch flakes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,9 @@ on:
 
 env:
   RUSTFLAGS: -A deprecated # Allow deprecated warnings, we are awaiting an updated k256 crate
+  # Disable cargo's HTTP/2 multiplexing to avoid intermittent
+  # "[16] Error in the HTTP2 framing layer" failures when fetching from crates.io.
+  CARGO_HTTP_MULTIPLEXING: false
 
 # Wheels are built against the stable ABI (pyo3 abi3-py311), so a single
 # cp311-abi3 wheel per platform covers Python 3.11 through 3.14 and beyond.

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -4,6 +4,9 @@ permissions:
   contents: read
 env:
   RUSTFLAGS: -A deprecated # Allow deprecated warnings, we are awaiting an updated k256 crate
+  # Disable cargo's HTTP/2 multiplexing to avoid intermittent
+  # "[16] Error in the HTTP2 framing layer" failures when fetching from crates.io.
+  CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   python-lint:


### PR DESCRIPTION
## What

Adds `CARGO_HTTP_MULTIPLEXING: false` to the `env:` of both workflows (`on_push.yml` and `CI.yml`).

## Why

Runners intermittently fail cargo/maturin builds with:

```
download of py/o3/pyo3-macros failed
Caused by: curl failed
Caused by: [16] Error in the HTTP2 framing layer
```

This is a known cargo + crates.io HTTP/2 flake (it just hit #121's run, which passed on a plain re-run). Disabling HTTP/2 multiplexing makes cargo issue one request per connection, sidestepping the framing-layer bug — at a negligible cost to fetch throughput in CI.

Both YAML files validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)