### PR TITLE
feat(peer): make connect/handshake timeouts configurable via env vars

### DIFF
--- a/src/peer/peer.rs
+++ b/src/peer/peer.rs
@@ -14,11 +14,26 @@ use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 use std::time::{Duration, UNIX_EPOCH};
 
-/// Time to wait for the initial TCP connection
+/// Default time to wait for the initial TCP connection.
+/// Override at runtime with env var `CHAIN_GANG_CONNECT_TIMEOUT_SECS`.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Time to wait for handshake messages before failing to connect
+/// Default time to wait for handshake messages before failing to connect.
+/// Override at runtime with env var `CHAIN_GANG_HANDSHAKE_READ_TIMEOUT_SECS`.
 const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Read a `Duration` (whole seconds) from `env_var`, falling back to `default`
+/// when the var is unset or not a positive integer. Lets operators tune the
+/// handshake timeouts without a rebuild; with no env vars set, behaviour is
+/// unchanged.
+fn duration_from_env_secs(env_var: &str, default: Duration) -> Duration {
+    std::env::var(env_var)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&secs| secs > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(default)
+}
 
 /// Event emitted when a connection is established with the peer
 #[derive(Clone, Debug)]
@@ -343,9 +358,15 @@ impl Peer {
     ) -> Result<TcpStream, ChainGangError> {
         // Connect over TCP
         let tcp_addr = SocketAddr::new(self.ip, self.port);
-        let mut tcp_stream = TcpStream::connect_timeout(&tcp_addr, CONNECT_TIMEOUT)?;
+        let connect_timeout =
+            duration_from_env_secs("CHAIN_GANG_CONNECT_TIMEOUT_SECS", CONNECT_TIMEOUT);
+        let handshake_read_timeout = duration_from_env_secs(
+            "CHAIN_GANG_HANDSHAKE_READ_TIMEOUT_SECS",
+            HANDSHAKE_READ_TIMEOUT,
+        );
+        let mut tcp_stream = TcpStream::connect_timeout(&tcp_addr, connect_timeout)?;
         tcp_stream.set_nodelay(true)?; // Disable buffering
-        tcp_stream.set_read_timeout(Some(HANDSHAKE_READ_TIMEOUT))?;
+        tcp_stream.set_read_timeout(Some(handshake_read_timeout))?;
         tcp_stream.set_nonblocking(false)?;
 
         // Write our version


### PR DESCRIPTION
## Summary

The peer connect and handshake timeouts were hardcoded:

```rust
const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);          // TCP connect
const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(3);   // wait for version/verack
```

`3s` is aggressive for loaded / high-latency testnet peers that **accept the TCP connection but are slow to send `version`/`verack`** — they get cut off and logged as `Failed to complete handshake: TimedOut`, even though they're valid nodes that would complete given a little longer.

This makes both timeouts overridable at runtime via env vars, **defaults unchanged**:

| Env var | Default |
|---|---|
| `CHAIN_GANG_CONNECT_TIMEOUT_SECS` | 5 |
| `CHAIN_GANG_HANDSHAKE_READ_TIMEOUT_SECS` | 3 |

Unset or non-positive values fall back to the existing consts, so it's fully backward-compatible — **no caller changes required**, and behaviour is identical unless an operator opts in.

## Why env vars (not a `connect()` parameter)

Keeps `Peer::connect`'s signature stable, so existing consumers (`tx-server`'s sensor-factory, uaas, etc.) compile and behave unchanged. An operator can A/B-test handshake tolerance by setting one env var on the container — no API churn, no rebuild. If a richer config surface is wanted later, this can evolve into a builder/param without breaking anyone.

## Motivation / context

Downstream investigation in `tx-server` (nchain-innovation/tx-server#71 and follow-ups): a deployment was stuck at 2/7 connected sensors despite 8 TCP-reachable peers, with the majority of failures being `TimedOut` (not `ConnectionRefused`) at the handshake-read stage — consistent with slow-but-alive peers being cut off at 3s. This lets that deployment try a longer handshake window (e.g. `CHAIN_GANG_HANDSHAKE_READ_TIMEOUT_SECS=12`) and measure whether the connected count recovers, with a trivial revert.

## Verification

- `cargo build --lib` ✅
- `rustfmt --check src/peer/peer.rs` clean
- `cargo clippy --lib` introduces no new warnings (2 pre-existing warnings elsewhere are untouched)
- Behavioural: with no env vars set, `connect_timeout`/`handshake_read_timeout` resolve to the original 5s/3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)