### PR TITLE
feat(messages): serde Serialize/Deserialize for Tx and Block

### DIFF
--- a/src/messages/block.rs
+++ b/src/messages/block.rs
@@ -158,6 +158,18 @@ impl Serializable<Block> for Block {
     }
 }
 
+impl serde::Serialize for Block {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::util::serde_bytes::serialize(self, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Block {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        crate::util::serde_bytes::deserialize(deserializer)
+    }
+}
+
 impl Payload<Block> for Block {
     fn size(&self) -> usize {
         let mut size = BlockHeader::SIZE;
@@ -280,5 +292,20 @@ mod tests {
         block.write(&mut v).unwrap();
         assert!(v.len() == block.size());
         assert!(Block::read(&mut Cursor::new(&v)).unwrap() == block);
+    }
+
+    #[test]
+    fn serde_bytes_match_serializable() {
+        let wire = hex::decode("010000004860eb18bf1b1620e37e9490fc8a427514416fd75159ab86688e9a8300000000d5fdcc541e25de1c7a5addedf24858b8bb665c9f36ef744ee42c316022c90f9bb0bc6649ffff001d08d2bd610101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d010bffffffff0100f2052a010000004341047211a824f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073dee6c89064984f03385237d92167c13e236446b417ab79a0fcae412ae3316b77ac00000000").unwrap();
+        let block = Block::read(&mut Cursor::new(&wire)).unwrap();
+
+        // The serde representation is exactly the raw wire-format bytes.
+        let json = serde_json::to_string(&block).unwrap();
+        let encoded: Vec<u8> = serde_json::from_str(&json).unwrap();
+        assert_eq!(encoded, wire);
+
+        // ... and it round-trips back to an identical Block.
+        let decoded: Block = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, block);
     }
 }

--- a/src/messages/tx.rs
+++ b/src/messages/tx.rs
@@ -269,6 +269,18 @@ impl Serializable<Tx> for Tx {
     }
 }
 
+impl serde::Serialize for Tx {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::util::serde_bytes::serialize(self, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Tx {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        crate::util::serde_bytes::deserialize(deserializer)
+    }
+}
+
 impl Payload<Tx> for Tx {
     fn size(&self) -> usize {
         let mut size = 8;
@@ -573,5 +585,36 @@ mod tests {
                 Network::BSV_Mainnet,
             )
             .is_err());
+    }
+
+    #[test]
+    fn serde_bytes_match_serializable() {
+        let tx = Tx {
+            version: 1,
+            inputs: vec![TxIn {
+                prev_output: OutPoint {
+                    hash: Hash256([9; 32]),
+                    index: 9,
+                },
+                unlock_script: Script(vec![1, 3, 5, 7, 9]),
+                sequence: 100,
+            }],
+            outputs: vec![TxOut {
+                satoshis: 99,
+                lock_script: Script(vec![1, 2, 3, 4, 5]),
+            }],
+            lock_time: 1000,
+        };
+
+        // The serde representation is exactly the raw wire-format bytes.
+        let mut wire = Vec::new();
+        tx.write(&mut wire).unwrap();
+        let json = serde_json::to_string(&tx).unwrap();
+        let encoded: Vec<u8> = serde_json::from_str(&json).unwrap();
+        assert_eq!(encoded, wire);
+
+        // ... and it round-trips back to an identical Tx.
+        let decoded: Tx = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, tx);
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -30,6 +30,7 @@ pub use self::hash160::{hash160, Hash160};
 pub use self::hash256::{sha256d, Hash256};
 #[allow(unused_imports)]
 pub use self::serdes::Serializable;
+pub use self::serdes::serde_bytes;
 
 /// Gets the time in seconds since a time in the past
 pub fn secs_since(time: SystemTime) -> u32 {

--- a/src/util/serdes.rs
+++ b/src/util/serdes.rs
@@ -13,6 +13,67 @@ pub trait Serializable<T> {
     fn write(&self, writer: &mut dyn Write) -> io::Result<()>;
 }
 
+/// Serde glue that (de)serializes a [`Serializable`] type using its raw wire-format bytes.
+///
+/// The produced representation is exactly the byte stream written by
+/// [`Serializable::write`], so it round-trips through [`Serializable::read`] and matches
+/// the on-the-wire encoding used elsewhere in the crate.
+pub mod serde_bytes {
+    use super::Serializable;
+    use serde::de::{Error as DeError, SeqAccess, Visitor};
+    use serde::ser::Error as SerError;
+    use serde::{Deserializer, Serializer};
+    use std::fmt;
+    use std::io::Cursor;
+
+    /// Serializes `value` as the raw bytes produced by [`Serializable::write`].
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serializable<T>,
+        S: Serializer,
+    {
+        let mut bytes = Vec::new();
+        value.write(&mut bytes).map_err(S::Error::custom)?;
+        serializer.serialize_bytes(&bytes)
+    }
+
+    /// Deserializes a [`Serializable`] type from the raw bytes written by [`serialize`].
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: Serializable<T>,
+        D: Deserializer<'de>,
+    {
+        struct BytesVisitor;
+
+        impl<'de> Visitor<'de> for BytesVisitor {
+            type Value = Vec<u8>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a byte array")
+            }
+
+            fn visit_bytes<E: DeError>(self, v: &[u8]) -> Result<Self::Value, E> {
+                Ok(v.to_vec())
+            }
+
+            fn visit_byte_buf<E: DeError>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+                Ok(v)
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut bytes = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    bytes.push(byte);
+                }
+                Ok(bytes)
+            }
+        }
+
+        let bytes = deserializer.deserialize_byte_buf(BytesVisitor)?;
+        T::read(&mut Cursor::new(bytes)).map_err(D::Error::custom)
+    }
+}
+
 impl Serializable<[u8; 16]> for [u8; 16] {
     fn read(reader: &mut dyn Read) -> Result<[u8; 16], ChainGangError> {
         let mut d = [0; 16];


### PR DESCRIPTION
## Summary

`Tx` and `Block` previously did not implement `serde::Serialize`/`Deserialize`. This adds those impls, encoding each type as its **raw wire-format byte stream** — exactly the bytes produced by `Serializable::write` and consumed by `Serializable::read` — rather than a struct-shaped encoding.

## Changes

- **`util::serdes`** — new reusable `serde_bytes` helper module. Generic `serialize`/`deserialize` functions bridge any `Serializable<T>` to serde via `serialize_bytes`, with a visitor that accepts byte strings, byte buffers, and integer sequences (works across both JSON and binary formats).
- **`Tx`** and **`Block`** — hand-written `Serialize`/`Deserialize` impls delegating to the helper.

## Tests

Added `serde_bytes_match_serializable` round-trip tests in the existing `tx.rs` and `block.rs` test modules. Each asserts the serde output equals the `Serializable::write` byte stream and decodes back to an identical value; the `Block` test reuses the block-1 hex fixture from the neighboring `read_bytes` test.

All 186 lib tests pass (`cargo test --lib`).

## Notes

- The field types (`Script`, `TxIn`, `TxOut`, `OutPoint`, `BlockHeader`) are intentionally **not** serde-derived — the byte-stream approach does not recurse through serde, and struct-shaped sub-types would be inconsistent with the byte encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)