### PR TITLE
deps: bump dependency versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ byteorder = "1.5"
 dns-lookup = "3.0.1"
 hex = "0.4.3"
 linked-hash-map = "0.5"
-log = { version = "0.4.32", features = ["max_level_trace", "release_max_level_warn"] }
-thiserror = "2.0.18"
+log = { version = "0.4.33", features = ["max_level_trace", "release_max_level_warn"] }
+thiserror = "2.0.19"
 url = "2.5.8"
 
 
@@ -23,11 +23,11 @@ url = "2.5.8"
 murmur3 = "0.5.2"
 num-bigint = "0.5.1"
 num-traits = "0.2"
-rand = "0.10.1"
+rand = "0.10.2"
 ripemd = "0.2.0"
 sha1 = "0.11.0"
 sha2 = "0.11.0"
-k256 = { version = "0.14.0-rc.12", features = ["alloc", "arithmetic", "digest", "ecdsa", "getrandom", "pkcs8", "precomputed-tables", "schnorr",
+k256 = { version = "0.14.0", features = ["alloc", "arithmetic", "digest", "ecdsa", "getrandom", "pkcs8", "precomputed-tables", "schnorr",
     "sha2", "sha256", "signature", "std"]}
 snowflake = "1.3"
 hmac = "0.13.0"
@@ -35,18 +35,18 @@ base58 = "0.2.0"
 pbkdf2 = { version = "0.13.0", features = ["hmac", "sha2"] }
 
 # Used by the interface feature
-serde = { version = "1.0.228", features = ["derive"], optional = true }
-serde_json = { version = "1.0.150", optional = true }
+serde = { version = "1.0.229", features = ["derive"], optional = true }
+serde_json = { version = "1.0.151", optional = true }
 reqwest = { version = "0.13.4", features = ["json"], optional = true }
 async-mutex = { version = "1.4.1", optional = true }
-async-trait = { version = "0.1.89", optional = true }
+async-trait = { version = "0.1.91", optional = true }
 
 # For python feature
 # abi3-py311 builds against the stable ABI: one wheel (cp311-abi3) works on
 # 3.11, 3.12, 3.13, 3.14 and every future CPython, so no per-version matrix
 # and no missing-version gaps. Floor matches `requires-python` in pyproject.toml.
 pyo3 = { version = "0.29.0", optional = true, features = ["abi3-py311"] }
-regex = "1.12.4"
+regex = "1.13.1"
 lazy_static = "1.5.0"
 typenum = "1.20.1"
 


### PR DESCRIPTION
## Summary

Raises the manifest minimum versions for several dependencies. The notable one is **`k256` `0.14.0-rc.12` → `0.14.0`** (release candidate → stable); the rest are patch/minor bumps.

| Dependency | From | To |
|------------|------|-----|
| `k256` | `0.14.0-rc.12` | `0.14.0` |
| `log` | `0.4.32` | `0.4.33` |
| `thiserror` | `2.0.18` | `2.0.19` |
| `rand` | `0.10.1` | `0.10.2` |
| `serde` | `1.0.228` | `1.0.229` |
| `serde_json` | `1.0.150` | `1.0.151` |
| `async-trait` | `0.1.89` | `0.1.91` |
| `regex` | `1.12.4` | `1.13.1` |

`Cargo.lock` already resolved to these exact versions, so no lockfile change is needed — this only tightens the manifest floors to match what's built.

## Verification

- `cargo build` — clean
- `cargo test --lib` — all 186 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)