### PR TITLE
Prepare for crates.io publication + CI publish job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,3 +150,42 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
+
+  crates-io:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: true
+      - name: Resolve version and check tag
+        id: version
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "Cargo.toml version: $VERSION, tag: $TAG"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "::error::Git tag ($TAG) does not match Cargo.toml version ($VERSION)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Skip if already published
+        id: published
+        run: |
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://crates.io/api/v1/crates/chain-gang/${{ steps.version.outputs.version }}")
+          if [ "$CODE" = "200" ]; then
+            echo "chain-gang ${{ steps.version.outputs.version }} already on crates.io — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish to crates.io
+        if: steps.published.outputs.skip == 'false'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,10 @@
 name = "chain-gang"
 version = "0.10.0"
 description = "This is a library that enables monitoring of multiple blockchains (BTC, BCH, BSV)."
-# repository = "https://github.com/brentongunning/rust-sv"
-authors = ["Arthur Gordon <a.gordon@nchain.com>"]
+repository = "https://github.com/nchain-innovation/chain-gang"
+homepage = "https://github.com/nchain-innovation/chain-gang"
+documentation = "https://docs.rs/chain-gang"
+authors = ["Arthur Gordon <a.gordon@teranode.group>"]
 keywords = ["bitcoin", "sv", "cash", "crypto"]
 license = "MIT"
 edition = "2021"

--- a/docs/README-chain-gang.md
+++ b/docs/README-chain-gang.md
@@ -2,8 +2,6 @@
 
 This is a Rust library that enables interacting with Bitcoin derived blockchains.
 
-This file is the **crates.io / docs.rs** readme (`Cargo.toml` → `readme = "docs/README-chain-gang.md"`). The GitHub repo root uses [README.md](../README.md); PyPI uses [README-pypi.md](../README-pypi.md).
-
 This library currently supports the following blockchains:
 
 | Name | Code | Networks |
@@ -25,7 +23,7 @@ BSV only Features
 * Wallet key derivation, BIP-32 HD wallets (`HdWallet`), and mnemonic parsing
 * Various Bitcoin primitives
 * Genesis upgrade support
-* [Chronicle upgrade](Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules)
+* [Chronicle upgrade](https://github.com/nchain-innovation/chain-gang/blob/main/docs/Chronicle.md) (OTDA sighash, opcodes, two-phase eval, `tx.version > 1` rules)
 
 `Chain-gang` is based on `Rust-SV` An open source library to build Bitcoin SV applications and infrastructure in Rust. The documentation for `Rust-SV` can be found here: 
 [Rust-SV Documentation](https://docs.rs/sv/)
@@ -33,10 +31,10 @@ BSV only Features
 
 # Installation
 
-To call the library from a Rust project add the following line to to Cargo.toml:
+To call the library from a Rust project add the following line to Cargo.toml:
 ```toml
-chain-gang = { path = "../chain-gang" }
-``` 
+chain-gang = "0.10"
+```
 
 ## Feature Flags
 
@@ -54,11 +52,11 @@ To build the library with the `python` feature
 ```bash
 cargo build --features "python"
 ```
-For more details of the `python` feature see [python/README.md](../python/README.md). Full documentation index: [docs/README.md](README.md). HD wallets: [BIP-32.md](BIP-32.md).
+For more details of the `python` feature see [python/README.md](https://github.com/nchain-innovation/chain-gang/blob/main/python/README.md). Full documentation index: [docs/README.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/README.md). HD wallets: [BIP-32.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/BIP-32.md).
 
 ## HD wallets (BIP-32)
 
-```rust
+```rust,ignore
 use chain_gang::network::Network;
 use chain_gang::wallet::{HdWallet, bip44_path, BSV_COIN_TYPE};
 
@@ -66,7 +64,7 @@ let hd = HdWallet::from_seed(Network::BSV_Mainnet, &seed)?;
 let addr = hd.address_at_bip44(BSV_COIN_TYPE, 0, true, 0)?;
 ```
 
-See [BIP-32.md](BIP-32.md) for mnemonics, watch-only `xpub`, and gap-limit scanning.
+See [BIP-32.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/BIP-32.md) for mnemonics, watch-only `xpub`, and gap-limit scanning.
 
 # Known limitations
 
@@ -74,8 +72,7 @@ This library should not be used for consensus code because its validation checks
 
 # License
 
-Still to be agreed with nChain IP etc.
+`chain-gang` is licensed under the [MIT license](https://github.com/nchain-innovation/chain-gang/blob/main/LICENSE).
 
-(Rust-sv is licensed under the MIT license.)
-See [here](LICENSE)
+It is based on `Rust-SV`, which is also licensed under the MIT license (see [LICENSE-rust-sv](https://github.com/nchain-innovation/chain-gang/blob/main/LICENSE-rust-sv)).
 

--- a/src/chronicle.rs
+++ b/src/chronicle.rs
@@ -1,7 +1,7 @@
 //! Chronicle (Bitcoin SV) helpers for transaction and script validation.
 //!
 //! By default this library gates Chronicle on **`tx.version > 1`** only. Pass block height
-//! and network to [`effective_chronicle_tx_version`] or [`Tx::validate_at_height`] for
+//! and network to [`effective_chronicle_tx_version`] or [`Tx::validate_at_height`](crate::messages::Tx::validate_at_height) for
 //! consensus-faithful activation at documented BSV block heights.
 //!
 //! See [docs/Chronicle.md](https://github.com/nchain-innovation/chain-gang/blob/main/docs/Chronicle.md)

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -1,4 +1,7 @@
-// This module provides the blockchain interface
+//! Blockchain interface for querying live chain state (balances, UTXOs, broadcast)
+//! via backends such as WhatsOnChain and UaaS.
+//!
+//! Enabled by the `interface` feature flag.
 
 pub mod blockchain_interface;
 pub mod uaas_interface;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! A foundation for building applications on Bitcoin SV using Rust.
+#![doc = include_str!("../docs/README-chain-gang.md")]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
## Summary

Prepares `chain-gang` for publication to crates.io and automates publishing via CI.

### Metadata & docs (`916d30d`)
- Add `repository`, `homepage`, and `documentation` fields to `Cargo.toml`; correct author email.
- Fix the crates.io README (`docs/README-chain-gang.md`):
  - Installation snippet now uses a version dependency (`chain-gang = "0.10"`) instead of a local path dep.
  - All relative links made absolute so they resolve on crates.io / docs.rs.
  - License section corrected to state MIT.
  - Removed maintainer-only meta note.
- Include the README as crate-level docs (`#![doc = include_str!(...)]`) so docs.rs is populated.
- Fix a broken intra-doc link in `chronicle.rs` and add a module doc header to the `interface` module.

### CI publishing (`da13f1f`)
- New `crates-io` job in `CI.yml`, tag-triggered like the existing PyPI release job.
- Verifies the git tag matches `Cargo.toml`'s version.
- Skips (rather than fails) when the version is already on crates.io, since crates.io versions are immutable.

## Verification
- `cargo build`, `cargo test --doc`, `cargo doc --no-deps` all clean (zero warnings).
- `cargo publish --dry-run` passes.

## Required before this can publish
1. Add a `CARGO_REGISTRY_TOKEN` repository secret (crates.io API token).
2. Seed the first version — `v0.10.0` is already tagged, so either run `cargo publish` locally once for `0.10.0`, or bump to `0.10.1` and let CI publish it on the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)