### PR TITLE
Fix opcode 102 name and inconsistent network parsing

### DIFF
--- a/python/src/tx_engine/engine/op_code_names.py
+++ b/python/src/tx_engine/engine/op_code_names.py
@@ -30,7 +30,7 @@ OP_CODE_NAMES: Dict[int, str] = {
     99: "OP_IF",
     100: "OP_NOTIF",
     101: "OP_VERIF",
-    102: "OP_NOTVERIF",
+    102: "OP_VERNOTIF",
     103: "OP_ELSE",
     104: "OP_ENDIF",
     105: "OP_VERIFY",

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -44,6 +44,26 @@ impl fmt::Display for Network {
     }
 }
 
+/// Parse a network from its canonical name (the inverse of [`Display`]).
+impl std::str::FromStr for Network {
+    type Err = crate::util::ChainGangError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "BSV_Mainnet" => Ok(Network::BSV_Mainnet),
+            "BSV_Testnet" => Ok(Network::BSV_Testnet),
+            "BSV_STN" => Ok(Network::BSV_STN),
+            "BTC_Mainnet" => Ok(Network::BTC_Mainnet),
+            "BTC_Testnet" => Ok(Network::BTC_Testnet),
+            "BCH_Mainnet" => Ok(Network::BCH_Mainnet),
+            "BCH_Testnet" => Ok(Network::BCH_Testnet),
+            _ => Err(crate::util::ChainGangError::BadData(format!(
+                "Unknown network: {s}"
+            ))),
+        }
+    }
+}
+
 impl Network {
     /// Converts an integer to a network type
     /// `pub fn from_u8(x: u8) -> Result<Network> {`
@@ -258,5 +278,38 @@ impl Network {
     /// Creates a new DNS seed iterator for this network
     pub fn seed_iter(&self) -> SeedIter {
         SeedIter::new(&self.seeds(), self.port())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_round_trips_display_for_all_networks() {
+        for net in [
+            Network::BSV_Mainnet,
+            Network::BSV_Testnet,
+            Network::BSV_STN,
+            Network::BTC_Mainnet,
+            Network::BTC_Testnet,
+            Network::BCH_Mainnet,
+            Network::BCH_Testnet,
+        ] {
+            let parsed: Network = net.to_string().parse().unwrap();
+            assert_eq!(parsed, net);
+        }
+    }
+
+    #[test]
+    fn from_str_accepts_non_bsv_networks() {
+        // Regression: these used to be rejected on some code paths (e.g. tx parsing).
+        assert_eq!("BTC_Mainnet".parse::<Network>().unwrap(), Network::BTC_Mainnet);
+        assert_eq!("BCH_Testnet".parse::<Network>().unwrap(), Network::BCH_Testnet);
+    }
+
+    #[test]
+    fn from_str_rejects_unknown_network() {
+        assert!("nope".parse::<Network>().is_err());
     }
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -152,14 +152,7 @@ pub fn py_address_to_public_key_hash(py: Python, address: &str) -> PyResult<Py<P
 #[pyfunction(name = "public_key_to_address")]
 pub fn py_public_key_to_address(public_key: &[u8], network: &str) -> PyResult<String> {
     // network conversion
-    let network_type = match network {
-        "BSV_Mainnet" => Network::BSV_Mainnet,
-        "BSV_Testnet" => Network::BSV_Testnet,
-        _ => {
-            let msg = format!("Unknown network: {}", network);
-            return Err(ChainGangError::BadData(msg).into());
-        }
-    };
+    let network_type: Network = network.parse()?;
     Ok(public_key_to_address(public_key, network_type)?)
 }
 

--- a/src/python/py_tx.rs
+++ b/src/python/py_tx.rs
@@ -17,14 +17,7 @@ use std::{
 };
 
 fn parse_network(network: &str) -> Result<Network, ChainGangError> {
-    match network {
-        "BSV_Mainnet" => Ok(Network::BSV_Mainnet),
-        "BSV_Testnet" => Ok(Network::BSV_Testnet),
-        "BSV_STN" => Ok(Network::BSV_STN),
-        _ => Err(ChainGangError::BadData(format!(
-            "Unknown network: {network}"
-        ))),
-    }
+    network.parse()
 }
 
 fn build_processed_utxos(

--- a/src/python/py_wallet.rs
+++ b/src/python/py_wallet.rs
@@ -106,16 +106,7 @@ pub fn p2pkh_pyscript(h160: &[u8]) -> PyScript {
 }
 
 pub fn str_to_network(network: &str) -> Option<Network> {
-    match network {
-        "BSV_Mainnet" => Some(Network::BSV_Mainnet),
-        "BSV_Testnet" => Some(Network::BSV_Testnet),
-        "BSV_STN" => Some(Network::BSV_STN),
-        "BTC_Mainnet" => Some(Network::BTC_Mainnet),
-        "BTC_Testnet" => Some(Network::BTC_Testnet),
-        "BCH_Mainnet" => Some(Network::BCH_Mainnet),
-        "BCH_Testnet" => Some(Network::BCH_Testnet),
-        _ => None,
-    }
+    network.parse().ok()
 }
 
 pub fn wallet_from_int(network: &str, int_rep: BigInt) -> Result<PyWallet, ChainGangError> {


### PR DESCRIPTION
Fixes the two confirmed correctness bugs surfaced by the duplication review.

## 1. Opcode 102 had the wrong name in Python's reverse map
`python/.../op_code_names.py` mapped `102 → "OP_NOTVERIF"`, but every other opcode table (`op_codes.rs`, `op_codes.py`) and the interpreter (`push.rs`, `eval.rs`, `format.rs`) use **`OP_VERNOTIF`**. An int→name lookup on opcode 102 returned a name that appears nowhere else in the codebase. Corrected to `OP_VERNOTIF`.

## 2. `str → Network` parsing accepted different networks on different code paths
The conversion was hand-duplicated in the PyO3 bindings with inconsistent coverage:
- `py_wallet::str_to_network` — all 7 networks
- `py_tx::parse_network` — only the 3 BSV networks
- `py_public_key_to_address` (mod.rs) — only 2 networks inline

So `"BTC_Mainnet"` succeeded via wallet calls but errored via tx / address calls.

**Fix:** added a canonical `impl FromStr for Network` in `network.rs` (the exact inverse of the existing `Display` impl) as the single source of truth, and routed all three binding helpers through it via `str::parse`. This also removes the duplication that caused the drift.

## Tests
- New unit tests in `network.rs`: `Display`↔`FromStr` round-trip for all 7 networks, a regression test for the non-BSV networks, and an unknown-network error case.
- Full suite green: `cargo test` 189 passed; `cargo build --all-features` clean (no warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)