### PR TITLE
Extract shared HTTP status check in blockchain interfaces

### DIFF
--- a/src/interface/blockchain_interface.rs
+++ b/src/interface/blockchain_interface.rs
@@ -34,6 +34,25 @@ pub struct UtxoEntry {
 /// Type to represent UTXO set
 pub type Utxo = Vec<UtxoEntry>;
 
+/// Returns `response` unchanged if its HTTP status is 200, otherwise logs the
+/// request URL and returns a [`ChainGangError::ResponseError`].
+///
+/// Shared by the HTTP-backed blockchain interfaces so the status check lives in
+/// one place.
+pub(crate) fn check_status(
+    response: reqwest::Response,
+    url: impl std::fmt::Display,
+) -> Result<reqwest::Response, ChainGangError> {
+    if response.status() != 200 {
+        log::warn!("url = {}", url);
+        return Err(ChainGangError::ResponseError(format!(
+            "response.status() = {}",
+            response.status()
+        )));
+    }
+    Ok(response)
+}
+
 /// Trait of the blockchain interface
 ///
 #[async_trait]

--- a/src/interface/uaas_interface.rs
+++ b/src/interface/uaas_interface.rs
@@ -6,7 +6,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    interface::blockchain_interface::{Balance, BlockchainInterface, Utxo},
+    interface::blockchain_interface::{check_status, Balance, BlockchainInterface, Utxo},
     messages::{BlockHeader, Tx},
     network::Network,
     util::{ChainGangError, Serializable},
@@ -149,13 +149,7 @@ impl UaaSInterface {
 
         let status_url = self.url.join("/status").unwrap();
         let response = reqwest::get(status_url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &status_url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &status_url)?;
         let txt = match response.text().await {
             Ok(txt) => txt,
             Err(err) => {
@@ -176,13 +170,7 @@ impl UaaSInterface {
 
         let status_url = self.url.join("/block/latest").unwrap();
         let response = reqwest::get(status_url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &status_url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &status_url)?;
 
         let txt = match response.text().await {
             Ok(txt) => txt,
@@ -205,13 +193,7 @@ impl UaaSInterface {
 
         let collection_url = self.url.join("/collection").unwrap();
         let response = reqwest::get(collection_url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &collection_url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &collection_url)?;
 
         let txt = match response.text().await {
             Ok(txt) => txt,
@@ -245,13 +227,7 @@ impl UaaSInterface {
             .send()
             .await?;
 
-        if response.status() != 200 {
-            log::warn!("url = {}", &add_monitor_url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        check_status(response, &add_monitor_url)?;
         Ok(())
     }
 
@@ -265,13 +241,7 @@ impl UaaSInterface {
 
         let response = client.delete(delete_monitor_url.clone()).send().await?;
 
-        if response.status() != 200 {
-            log::warn!("url = {}", &delete_monitor_url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        check_status(response, &delete_monitor_url)?;
         Ok(())
     }
 }
@@ -288,13 +258,7 @@ impl BlockchainInterface for UaaSInterface {
 
         let status_url = self.url.join("/status").unwrap();
         let response = reqwest::get(status_url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &status_url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &status_url)?;
         match response.text().await {
             Ok(_txt) => Ok(()),
             Err(err) => Err(ChainGangError::ResponseError(format!(
@@ -312,13 +276,7 @@ impl BlockchainInterface for UaaSInterface {
         let url = self.url.join(&get_utxo_balance_url).unwrap();
 
         let response = reqwest::get(url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
 
         let txt = match response.text().await {
             Ok(txt) => txt,
@@ -353,13 +311,7 @@ impl BlockchainInterface for UaaSInterface {
         let url = self.url.join(&get_utxo_url).unwrap();
 
         let response = reqwest::get(url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
 
         let txt = match response.text().await {
             Ok(txt) => txt,
@@ -425,13 +377,7 @@ impl BlockchainInterface for UaaSInterface {
         let url = self.url.join(&get_tx_url).unwrap();
 
         let response = reqwest::get(url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         let txt = match response.text().await {
             Ok(txt) => txt,
             Err(x) => {
@@ -465,13 +411,7 @@ impl BlockchainInterface for UaaSInterface {
         let url = self.url.join("/block/last/hex").unwrap();
 
         let response = reqwest::get(url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         let txt = match response.text().await {
             Ok(txt) => txt,
             Err(x) => {
@@ -504,13 +444,7 @@ impl BlockchainInterface for UaaSInterface {
 
         let status_url = self.url.join("/block/latest").unwrap();
         let response = reqwest::get(status_url.clone()).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &status_url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &status_url)?;
 
         return match response.text().await {
             Ok(headers) => Ok(headers),

--- a/src/interface/woc_interface.rs
+++ b/src/interface/woc_interface.rs
@@ -5,7 +5,7 @@ use crate::util::Serializable;
 use serde::Serialize;
 
 use crate::{
-    interface::blockchain_interface::{Balance, BlockchainInterface, Utxo},
+    interface::blockchain_interface::{check_status, Balance, BlockchainInterface, Utxo},
     messages::{BlockHeader, Tx},
     network::Network,
     util::ChainGangError,
@@ -61,13 +61,7 @@ impl BlockchainInterface for WocInterface {
         let network = self.get_network_str();
         let url = format!("https://api.whatsonchain.com/v1/bsv/{network}/woc");
         let response = reqwest::get(&url).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         match response.text().await {
             Ok(txt) if txt == "Whats On Chain" => Ok(()),
             Ok(txt) => Err(ChainGangError::ResponseError(format!(
@@ -89,13 +83,7 @@ impl BlockchainInterface for WocInterface {
         let url =
             format!("https://api.whatsonchain.com/v1/bsv/{network}/address/{address}/balance");
         let response = reqwest::get(&url).await?;
-        if response.status() != 200 {
-            warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         let txt = match response.text().await {
             Ok(txt) => txt,
             Err(x) => {
@@ -128,13 +116,7 @@ impl BlockchainInterface for WocInterface {
         let url =
             format!("https://api.whatsonchain.com/v1/bsv/{network}/address/{address}/unspent");
         let response = reqwest::get(&url).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         let txt = match response.text().await {
             Ok(txt) => txt,
             Err(x) => {
@@ -195,13 +177,7 @@ impl BlockchainInterface for WocInterface {
         let network = self.get_network_str();
         let url = format!("https://api.whatsonchain.com/v1/bsv/{network}/tx/{txid}/hex");
         let response = reqwest::get(&url).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         match response.text().await {
             Ok(txt) => {
                 let bytes = hex::decode(txt)?;
@@ -222,13 +198,7 @@ impl BlockchainInterface for WocInterface {
         let url =
             format!("https://api.whatsonchain.com/v1/bsv/{network}/block/headers/latest?count=1");
         let response = reqwest::get(&url).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         match response.text().await {
             Ok(txt) => {
                 let bytes = hex::decode(txt)?;
@@ -248,13 +218,7 @@ impl BlockchainInterface for WocInterface {
         let network = self.get_network_str();
         let url = format!("https://api.whatsonchain.com/v1/bsv/{network}/block/headers");
         let response = reqwest::get(&url).await?;
-        if response.status() != 200 {
-            log::warn!("url = {}", &url);
-            return Err(ChainGangError::ResponseError(format!(
-                "response.status() = {}",
-                response.status()
-            )));
-        };
+        let response = check_status(response, &url)?;
         match response.text().await {
             Ok(headers) => Ok(headers),
             Err(x) => Err(ChainGangError::ResponseError(format!(


### PR DESCRIPTION
Addresses duplication-review item #3: the `reqwest::get` + status-check boilerplate repeated **17×** across the two HTTP blockchain backends.

## Before
Every request method contained an identical block:
```rust
let response = reqwest::get(&url).await?;
if response.status() != 200 {
    log::warn!("url = {}", &url);
    return Err(ChainGangError::ResponseError(format!(
        "response.status() = {}", response.status()
    )));
};
```
(11× in `uaas_interface.rs`, 6× in `woc_interface.rs` — all byte-identical apart from the URL variable name).

## After
A single helper in `blockchain_interface.rs`:
```rust
pub(crate) fn check_status(
    response: reqwest::Response,
    url: impl std::fmt::Display,
) -> Result<reqwest::Response, ChainGangError> { ... }
```
Each call site becomes `let response = check_status(response, &url)?;` (or `check_status(response, &url)?;` where the body isn't read).

## Behaviour preserved
The 17 blocks were verified byte-identical (modulo the URL variable), and the helper keeps the same `warn!("url = …")` log and `ResponseError("response.status() = …")` message and the same `!= 200` check.

## Verification
- `cargo build --features interface` and `--all-features`: **warning-free**.
- `cargo test --all-features`: 194 + 10 doctests pass.

Net: **−121 / +38** lines (~80 lines of duplication removed). Independent of the other open PRs (touches only `src/interface/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)