### PR TITLE
Single-source script-number-length limits across Rust/Python

### DIFF
--- a/python/src/tx_engine/engine/util.py
+++ b/python/src/tx_engine/engine/util.py
@@ -4,12 +4,14 @@ from typing import List, Final
 
 from .engine_types import StackElement
 
-# Maximum script number length before Genesis (equal to CScriptNum::MAXIMUM_ELEMENT_SIZE)
-MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS: Final = 4
-# Maximum script number length after Genesis (750 KB)
-MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS: Final = 750 * 1000
-# Maximum script number length after Chronicle (32 MB)
-MAX_SCRIPT_NUM_LENGTH_CHRONICLE: Final = 32 * 1024 * 1024
+# Script-number-length limits are defined once in the Rust core and re-exported
+# here, so the Rust and Python implementations cannot drift out of sync.
+from tx_engine.tx_engine import (  # type: ignore[attr-defined]
+    MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS,
+    MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS,
+    MAX_SCRIPT_NUM_LENGTH_CHRONICLE,
+)
+
 # Maximum size that we are using for legacy callers
 MAXIMUM_ELEMENT_SIZE: Final = MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -497,5 +497,20 @@ fn chain_gang(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyHdWatchWallet>()?;
     // stack class
     m.add_class::<PyStack>()?;
+
+    // Script-number-length limits — defined once here in the Rust core; the
+    // pure-Python engine imports these (see engine/util.py) so they can't drift.
+    m.add(
+        "MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS",
+        crate::script::MAX_SCRIPT_NUM_LENGTH_PREGENESIS,
+    )?;
+    m.add(
+        "MAX_SCRIPT_NUM_LENGTH_AFTER_GENESIS",
+        crate::script::MAX_SCRIPT_NUM_LENGTH_GENESIS,
+    )?;
+    m.add(
+        "MAX_SCRIPT_NUM_LENGTH_CHRONICLE",
+        crate::script::MAX_SCRIPT_NUM_LENGTH_CHRONICLE,
+    )?;
     Ok(())
 }


### PR DESCRIPTION
Addresses duplication-review item #5: the script-number-length limits were declared independently in Rust and Python.

## Before
- Rust: `src/script/stack.rs` — `MAX_SCRIPT_NUM_LENGTH_PREGENESIS = 4`, `_GENESIS = 750_000`, `_CHRONICLE = 32 * 1024 * 1024`.
- Python: `engine/util.py` re-declared the same three values as `MAX_SCRIPT_NUM_LENGTH_BEFORE_GENESIS` / `_AFTER_GENESIS` / `_CHRONICLE`.

They agreed today but had nothing keeping them in sync.

## After
The Rust core exposes the three constants through the PyO3 module (`tx_engine.tx_engine`), and `engine/util.py` imports them instead of re-declaring — Rust is now the single source of truth. `MAXIMUM_ELEMENT_SIZE` is still derived locally from the imported value.

The per-language selection helpers (`max_script_num_length`) are intentionally **not** merged: the Rust one is `Checker`-based and the Python one takes `(tx_version, pregenesis)`, so they can't share an implementation. Only the constants — the actual drift risk — are unified.

## Verification
- No circular import: the native module is imported first in `tx_engine/__init__.py`, so `engine/util.py` sees it already loaded.
- `cargo build --features python`, `cargo test --all-features` (194 + 10 doctests) pass.
- Python `unittest` suite: 208 pass, including `test_max_script_num_length` which pins the values (4 / 750_000 / 32 MB).
- `flake8` / `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)