### PR TITLE
Document the deliberate Rust/Python WhatsOnChain client parallel

### DIFF
--- a/python/src/tx_engine/interface/woc.py
+++ b/python/src/tx_engine/interface/woc.py
@@ -1,4 +1,10 @@
-""" What's on Chain interface
+""" What's On Chain (WoC) low-level request helpers (pure Python).
+
+A parallel Rust implementation of the WoC client lives in
+`src/interface/woc_interface.rs`. The two are deliberately independent so the
+Python package can reach WhatsOnChain without the Rust `interface` feature.
+Keep the endpoint paths and the network -> main/test/stn mapping in sync across
+both when either changes.
 """
 import logging
 import time

--- a/python/src/tx_engine/interface/woc_interface.py
+++ b/python/src/tx_engine/interface/woc_interface.py
@@ -1,4 +1,9 @@
-""" The Whats On Chain (WoC) interface to the BSV network
+""" The Whats On Chain (WoC) interface to the BSV network (pure Python).
+
+This is a deliberate parallel of the Rust `WocInterface` in
+`src/interface/woc_interface.rs`, kept independent so the Python package does
+not depend on the Rust `interface` feature. Keep endpoint paths and the
+network -> main/test/stn mapping in sync across both when either changes.
 """
 
 import logging

--- a/src/interface/woc_interface.rs
+++ b/src/interface/woc_interface.rs
@@ -1,3 +1,12 @@
+//! WhatsOnChain blockchain interface (Rust implementation).
+//!
+//! A parallel, independent pure-Python client lives in
+//! `python/src/tx_engine/interface/woc.py` and `woc_interface.py`. The
+//! duplication is deliberate: it lets the Python package talk to WhatsOnChain
+//! without depending on this crate's `interface` feature. When changing
+//! endpoint paths or the network -> `main`/`test`/`stn` mapping, update both
+//! implementations so they stay in sync.
+
 use async_trait::async_trait;
 use reqwest::StatusCode;
 


### PR DESCRIPTION
Addresses duplication-review item #7 — the WhatsOnChain client that exists in both Rust and pure Python.

The review classified this duplication as **intentional**: the Rust `WocInterface` (`src/interface/woc_interface.rs`) serves Rust consumers behind the `interface` feature, while the pure-Python client (`interface/woc.py` + `woc_interface.py`) lets the Python package reach WhatsOnChain **without** depending on the Rust `interface` feature. Merging them would couple the Python package to the native module — undesirable — so the correct action is to make the parallel explicit and maintainable, not to remove it.

## Change
Documentation only — cross-referencing notes added to all three files stating that:
- the two implementations are deliberately independent, and why;
- the endpoint paths and the network → `main`/`test`/`stn` mapping must be kept in sync across both when either changes.

No behaviour change. `cargo build --features interface` and `flake8` pass.

This completes the actionable follow-ups from the duplication review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)